### PR TITLE
Adds driver for Beckhoff El4102 analog output

### DIFF
--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -11,6 +11,7 @@ For every `JSD Device` there is an `Offline Device` to emulate the behavior of t
 | El3208   | Beckhoff     | 8-channel RTD Input                 |
 | El3602   | Beckhoff     | 2-channel +/-10v Diff. Analog Input |
 | El2124   | Beckhoff     | 4-channel 5v Digital Output         |
+| El4102   | Beckhoff     | 2-channel 0-10v Analog Output       |
 | AtiFts   | ATI          | Force-Torque Sensor                 |
 | JED0101  | JPL          | JPL EtherCAT Device 0101 - EELS     |
 | JED0200  | JPL          | JPL EtherCAT Device 0200 - SAEL     |
@@ -306,6 +307,17 @@ The permitted range values are:
 ``` yaml
 - device_class: El2124
   name: el2124_1
+```
+
+## El4102 (2-channel 0-10v Analog Output)
+
+**The El4102 device has no configuration parameters.**
+
+#### Example
+
+``` yaml
+- device_class: El4102
+  name: el4102_1
 ```
 
 ## El3318 (8-channel Thermocouple module)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(fastcat STATIC
     jsd/el3208.cc
     jsd/el3602.cc
     jsd/el2124.cc
+    jsd/el4102.cc
     jsd/el3104.cc
     jsd/el3202.cc
     jsd/el3318.cc
@@ -81,6 +82,7 @@ add_library(fastcat STATIC
     jsd/actuator_offline.cc
     jsd/egd_offline.cc
     jsd/el2124_offline.cc
+    jsd/el4102_offline.cc
     jsd/el3208_offline.cc
     jsd/el3602_offline.cc
     jsd/el3104_offline.cc

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -226,6 +226,13 @@ states:
     - name: level_ch4
       type: uint8_t
 
+  - name: el4102
+    fields:
+    - name: voltage_output_ch1
+      type: double
+    - name: voltage_output_ch2
+      type: double
+
   - name: el3208
     fields:
     - name: output_ch1
@@ -489,6 +496,20 @@ commands:
       type: uint8_t
     - name: channel_ch4
       type: uint8_t
+
+  - name: el4102_write_channel
+    fields:
+    - name: channel
+      type: uint8_t
+    - name: voltage_output
+      type: double
+
+  - name: el4102_write_all_channels
+    fields:
+    - name: voltage_output_ch1
+      type: double
+    - name: voltage_output_ch2
+      type: double
 
   - name: actuator_csp
     fields: 

--- a/src/jsd/el4102.cc
+++ b/src/jsd/el4102.cc
@@ -1,0 +1,86 @@
+// Include related header (for cc files)
+#include "fastcat/jsd/el4102.h"
+
+// Include c then c++ libraries
+#include <string.h>
+
+#include <cmath>
+#include <iostream>
+
+// Include external then project includes
+#include "fastcat/yaml_parser.h"
+
+fastcat::El4102::El4102()
+{
+  MSG_DEBUG("Constructed El4102");
+
+  state_       = std::make_shared<DeviceState>();
+  state_->type = EL4102_STATE;
+}
+
+bool fastcat::El4102::ConfigFromYaml(YAML::Node node)
+{
+  bool retval = ConfigFromYamlCommon(node);
+  jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);
+  return retval;
+}
+
+bool fastcat::El4102::ConfigFromYamlCommon(YAML::Node node)
+{
+  if (!ParseVal(node, "name", name_)) {
+    return false;
+  }
+  state_->name = name_;
+
+  jsd_slave_config_.configuration_active = true;
+  jsd_slave_config_.product_code         = JSD_EL4102_PRODUCT_CODE;
+  snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
+
+  return true;
+}
+
+bool fastcat::El4102::Read()
+{
+  const jsd_el4102_state_t* jsd_state =
+      jsd_el4102_get_state((jsd_t*)context_, slave_id_);
+
+  state_->el4102_state.voltage_output_ch1 = jsd_state->voltage_output[0];
+  state_->el4102_state.voltage_output_ch2 = jsd_state->voltage_output[1];
+
+  return true;
+}
+
+fastcat::FaultType fastcat::El4102::Process()
+{
+  jsd_el4102_process((jsd_t*)context_, slave_id_);
+  return NO_FAULT;
+}
+
+bool fastcat::El4102::Write(DeviceCmd& cmd)
+{
+  // The use of ERROR statements, which are not real-time safe, is deemed
+  // acceptable in this function. Their execution would imply the existence of
+  // a serious issue in the application's side that should be addressed.
+  if (cmd.type == EL4102_WRITE_CHANNEL_CMD) {
+    uint8_t ch = cmd.el4102_write_channel_cmd.channel;
+    if (ch < 1 || ch > JSD_EL4102_NUM_CHANNELS) {
+      ERROR("Channel must be in range (1,%u)", JSD_EL4102_NUM_CHANNELS);
+      return false;
+    }
+
+    jsd_el4102_write_single_channel(
+        (jsd_t*)context_, slave_id_, ch - 1,
+        cmd.el4102_write_channel_cmd.voltage_output);
+
+  } else if (cmd.type == EL4102_WRITE_ALL_CHANNELS_CMD) {
+    double output_array[JSD_EL4102_NUM_CHANNELS] = {
+        cmd.el4102_write_all_channels_cmd.voltage_output_ch1,
+        cmd.el4102_write_all_channels_cmd.voltage_output_ch2};
+
+    jsd_el4102_write_all_channels((jsd_t*)context_, slave_id_, output_array);
+  } else {
+    ERROR("Bad EL4102 command");
+    return false;
+  }
+  return true;
+}

--- a/src/jsd/el4102.h
+++ b/src/jsd/el4102.h
@@ -1,0 +1,32 @@
+#ifndef FASTCAT_EL4102_H_
+#define FASTCAT_EL4102_H_
+
+// Include related header (for cc files)
+
+// Include c then c++ libraries
+
+// Include external then project includes
+#include "fastcat/device_base.h"
+#include "jsd/jsd_el4102_pub.h"
+
+namespace fastcat
+{
+class El4102 : public DeviceBase
+{
+ public:
+  El4102();
+  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      Read() override;
+  FaultType Process() override;
+  bool      Write(DeviceCmd& cmd) override;
+
+ protected:
+  bool ConfigFromYamlCommon(YAML::Node node);
+
+ private:
+  jsd_slave_config_t jsd_slave_config_ = {0};
+};
+
+}  // namespace fastcat
+
+#endif

--- a/src/jsd/el4102_offline.cc
+++ b/src/jsd/el4102_offline.cc
@@ -1,0 +1,56 @@
+// Include related header (for cc files)
+#include "fastcat/jsd/el4102_offline.h"
+
+// Include c then c++ libraries
+
+// Include external then project includes
+
+bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node)
+{
+  return ConfigFromYamlCommon(node);
+}
+
+bool fastcat::El4102Offline::Read() { return true; }
+
+fastcat::FaultType fastcat::El4102Offline::Process()
+{
+  return DeviceBase::Process();
+}
+
+bool fastcat::El4102Offline::Write(DeviceCmd& cmd)
+{
+  // The use of ERROR statements, which are not real-time safe, is deemed
+  // acceptable in this function. Their execution would imply the existence of
+  // a serious issue in the application's side that should be addressed.
+  if (cmd.type == EL4102_WRITE_CHANNEL_CMD) {
+    uint8_t ch = cmd.el4102_write_channel_cmd.channel;
+    if (ch < 1 || ch > JSD_EL4102_NUM_CHANNELS) {
+      ERROR("Channel must be in range (1,%u)", JSD_EL4102_NUM_CHANNELS);
+      return false;
+    }
+    switch (cmd.el4102_write_channel_cmd.channel) {
+      case 1:
+        state_->el4102_state.voltage_output_ch1 =
+            cmd.el4102_write_channel_cmd.voltage_output;
+        break;
+      case 2:
+        state_->el4102_state.voltage_output_ch2 =
+            cmd.el4102_write_channel_cmd.voltage_output;
+        break;
+      default:
+        ERROR("Bad Channel value");
+        break;
+    }
+  } else if (cmd.type == EL4102_WRITE_ALL_CHANNELS_CMD) {
+    state_->el4102_state.voltage_output_ch1 =
+        cmd.el4102_write_all_channels_cmd.voltage_output_ch1;
+
+    state_->el4102_state.voltage_output_ch2 =
+        cmd.el4102_write_all_channels_cmd.voltage_output_ch2;
+
+  } else {
+    ERROR("Bad EL4102 Command");
+    return false;
+  }
+  return true;
+}

--- a/src/jsd/el4102_offline.h
+++ b/src/jsd/el4102_offline.h
@@ -1,0 +1,24 @@
+#ifndef FASTCAT_EL4102_OFFLINE_H_
+#define FASTCAT_EL4102_OFFLINE_H_
+
+// Include related header (for cc files)
+
+// Include c then c++ libraries
+
+// Include external then project includes
+#include "fastcat/jsd/el4102.h"
+
+namespace fastcat
+{
+class El4102Offline : public El4102
+{
+ public:
+  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      Read() override;
+  FaultType Process() override;
+  bool      Write(DeviceCmd& cmd) override;
+};
+
+}  // namespace fastcat
+
+#endif

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -33,16 +33,18 @@
 #include "fastcat/jsd/egd_offline.h"
 #include "fastcat/jsd/el2124.h"
 #include "fastcat/jsd/el2124_offline.h"
-#include "fastcat/jsd/el3208.h"
-#include "fastcat/jsd/el3208_offline.h"
-#include "fastcat/jsd/el3602.h"
-#include "fastcat/jsd/el3602_offline.h"
 #include "fastcat/jsd/el3104.h"
 #include "fastcat/jsd/el3104_offline.h"
 #include "fastcat/jsd/el3202.h"
 #include "fastcat/jsd/el3202_offline.h"
+#include "fastcat/jsd/el3208.h"
+#include "fastcat/jsd/el3208_offline.h"
 #include "fastcat/jsd/el3318.h"
 #include "fastcat/jsd/el3318_offline.h"
+#include "fastcat/jsd/el3602.h"
+#include "fastcat/jsd/el3602_offline.h"
+#include "fastcat/jsd/el4102.h"
+#include "fastcat/jsd/el4102_offline.h"
 #include "fastcat/jsd/jed0101.h"
 #include "fastcat/jsd/jed0101_offline.h"
 #include "fastcat/jsd/jed0200.h"
@@ -365,6 +367,9 @@ bool fastcat::Manager::ConfigJSDBusFromYaml(YAML::Node node)
 
     } else if (0 == device_class.compare("El2124")) {
       device = std::make_shared<El2124>();
+
+    } else if (0 == device_class.compare("El4102")) {
+      device = std::make_shared<El4102>();
 
     } else if (0 == device_class.compare("El3104")) {
       device = std::make_shared<El3104>();


### PR DESCRIPTION
Summary:
Adds the Fascat wrapper for the JSD driver of Beckhoff El4102
terminal. This is a 2-channel analog output of voltage range 0-10 V.

Test Plan:
Performed tests via a ROS node that communicates with the terminal.
The outputs were measured with a multimeter.

Reviewers: alex-brinkman, JosephBowkett