### PR TITLE
Support gain scheduling in EGD Fastcat driver.

### DIFF
--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -503,6 +503,12 @@ commands:
       type: bool
       comment: unused
 
+  - name: egd_sdo_enable_position_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
+
   - name: egd_sdo_enable_manual_gain_scheduling
     fields:
     - name: dummy

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -435,6 +435,11 @@ commands:
     - name: torque_offset_amps
       type: double
 
+  - name: egd_set_gain_scheduling_index
+    fields:
+    - name: gain_scheduling_index
+      type: uint16_t
+
   - name: egd_prof_pos
     fields: 
     - name: target_position
@@ -485,6 +490,24 @@ commands:
     fields:
     - name: unit_mode
       type: int32_t
+
+  - name: egd_sdo_disable_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
+
+  - name: egd_sdo_enable_speed_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
+
+  - name: egd_sdo_enable_manual_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
 
   - name: fts_tare
     fields:

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -324,6 +324,11 @@ bool fastcat::Egd::WriteProfiledMode(DeviceCmd& cmd)
           (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_SPEED);
       break;
     }
+    case EGD_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_POSITION);
+      break;
+    }
     default: {
       WARNING("That command type is not supported in this mode!");
       return false;

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -314,6 +314,16 @@ bool fastcat::Egd::WriteProfiledMode(DeviceCmd& cmd)
                                       cmd.egd_sdo_set_unit_mode_cmd.unit_mode);
       break;
     }
+    case EGD_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED);
+      break;
+    }
+    case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_SPEED);
+      break;
+    }
     default: {
       WARNING("That command type is not supported in this mode!");
       return false;
@@ -352,6 +362,12 @@ bool fastcat::Egd::WriteCSMode(DeviceCmd& cmd)
       jsd_egd_set_motion_command_cst((jsd_t*)context_, slave_id_, jsd_cmd);
       break;
     }
+    case EGD_SET_GAIN_SCHEDULING_INDEX_CMD: {
+      jsd_egd_set_gain_scheduling_index(
+          (jsd_t*)context_, slave_id_, true,
+          cmd.egd_set_gain_scheduling_index_cmd.gain_scheduling_index);
+      break;
+    }
     case EGD_RESET_CMD: {
       jsd_egd_reset((jsd_t*)context_, slave_id_);
       break;
@@ -369,6 +385,21 @@ bool fastcat::Egd::WriteCSMode(DeviceCmd& cmd)
     case EGD_SDO_SET_UNIT_MODE_CMD: {
       jsd_egd_async_sdo_set_unit_mode((jsd_t*)context_, slave_id_,
                                       cmd.egd_sdo_set_unit_mode_cmd.unit_mode);
+      break;
+    }
+    case EGD_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED);
+      break;
+    }
+    case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_SPEED);
+      break;
+    }
+    case EGD_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW);
       break;
     }
     default: {

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -397,6 +397,11 @@ bool fastcat::Egd::WriteCSMode(DeviceCmd& cmd)
           (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_SPEED);
       break;
     }
+    case EGD_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
+      jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+          (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_POSITION);
+      break;
+    }
     case EGD_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
           (jsd_t*)context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW);

--- a/src/jsd/egd_offline.cc
+++ b/src/jsd/egd_offline.cc
@@ -347,6 +347,10 @@ bool fastcat::EgdOffline::WriteProfiledMode(DeviceCmd& cmd)
       WARNING("Offline mode not implemented for SDO params");
       break;
     }
+    case EGD_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
     default: {
       WARNING("That command type is not supported in this mode!");
       return false;
@@ -423,6 +427,10 @@ bool fastcat::EgdOffline::WriteCSMode(DeviceCmd& cmd)
       break;
     }
     case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
+    case EGD_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
       WARNING("Offline mode not implemented for SDO params");
       break;
     }

--- a/src/jsd/egd_offline.cc
+++ b/src/jsd/egd_offline.cc
@@ -339,6 +339,14 @@ bool fastcat::EgdOffline::WriteProfiledMode(DeviceCmd& cmd)
       WARNING("Offline mode not implemented for SDO params");
       break;
     }
+    case EGD_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
+    case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
     default: {
       WARNING("That command type is not supported in this mode!");
       return false;
@@ -398,11 +406,27 @@ bool fastcat::EgdOffline::WriteCSMode(DeviceCmd& cmd)
           JSD_EGD_MODE_OF_OPERATION_DISABLED;
       break;
     }
+    case EGD_SET_GAIN_SCHEDULING_INDEX_CMD: {
+      WARNING("Offline mode not implemented for manual gain scheduling.");
+      break;
+    }
     case EGD_SDO_SET_DRIVE_POS_CMD: {
       WARNING("Offline mode not implemented for SDO params");
       break;
     }
     case EGD_SDO_SET_UNIT_MODE_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
+    case EGD_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
+    case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
+      WARNING("Offline mode not implemented for SDO params");
+      break;
+    }
+    case EGD_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD: {
       WARNING("Offline mode not implemented for SDO params");
       break;
     }


### PR DESCRIPTION
Summary:
Extends the EGD Fastcat driver to enable the selection of the
gain scheduling strategy for its controller and the selection of
particular gain sets when the strategy is manual scheduling.

Test Plan:
Tested on a ROS node that communicates with the Elmo
Gold Drive motor controller.

Reviewers: alex-brinkman, JosephBowkett
