### PR TITLE
Adds gain scheduling config to driver of EGD and Actuator.

### DIFF
--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -193,6 +193,7 @@ Engineering Units (EU) are radians for revolute actuators and meters for linear 
 | `winding_resistance`            | OPTIONAL: Winding resistance of motor for optional power calculation |
 | `torque_constant`               | OPTIONAL: Torque constant of motor for optional power calculation  |
 | `motor_encoder_gear_ratio`      | OPTIONAL: Capture any gear ratio between the motor and the encoder, i.e. an output encoder  |
+| `ctrl_gain_scheduling_mode`     | OPTIONAL: Gain scheduling mode for the drive's controller: `DISABLED`, `SPEED`, `POSITION`, and `MANUAL`. When not specified, the mode stored in the drive's non-volatile memory is used. |
 
 ### Implementation Notes
 

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -161,7 +161,7 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
   } else {
     // Use mode saved in driver's non-volatile memory.
     jsd_slave_config_.egd.ctrl_gain_scheduling_mode =
-        (jsd_egd_gain_scheduling_mode_t)-1;
+        JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
   }
 
   // overall_reduction must be set before using EuToCnts/CntsToEu

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -152,6 +152,18 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
     }
   }
 
+  std::string ctrl_gs_mode_string;
+  if (ParseOptVal(node, "ctrl_gain_scheduling_mode", ctrl_gs_mode_string)) {
+    if (!GSModeFromString(ctrl_gs_mode_string,
+                          jsd_slave_config_.egd.ctrl_gain_scheduling_mode)) {
+      return false;
+    }
+  } else {
+    // Use mode saved in driver's non-volatile memory.
+    jsd_slave_config_.egd.ctrl_gain_scheduling_mode =
+        (jsd_egd_gain_scheduling_mode_t)-1;
+  }
+
   // overall_reduction must be set before using EuToCnts/CntsToEu
   if (actuator_type_ == ACTUATOR_TYPE_REVOLUTE) {
     overall_reduction_ = counts_per_rev_ * gear_ratio_ / (2.0 * M_PI);
@@ -610,4 +622,24 @@ void fastcat::Actuator::EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd)
 void fastcat::Actuator::EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd)
 {
   jsd_egd_set_motion_command_cst((jsd_t*)context_, slave_id_, jsd_cst_cmd);
+}
+
+bool fastcat::Actuator::GSModeFromString(
+    std::string gs_mode_string, jsd_egd_gain_scheduling_mode_t& gs_mode)
+{
+  MSG("Converting gain scheduling mode to string.");
+  if (gs_mode_string.compare("DISABLED") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED;
+  } else if (gs_mode_string.compare("SPEED") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_SPEED;
+  } else if (gs_mode_string.compare("POSITION") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_POSITION;
+  } else if (gs_mode_string.compare("MANUAL") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW;
+  } else {
+    ERROR("Gain scheduling mode %s is invalid", gs_mode_string.c_str());
+    return false;
+  }
+
+  return true;
 }

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -137,6 +137,10 @@ class Actuator : public DeviceBase
   int32_t                   egd_pos_offset_cnts_ = 1;
 
   ActuatorCalibrateCmd cal_cmd_;
+
+ private:
+  bool GSModeFromString(std::string                     gs_mode_string,
+                        jsd_egd_gain_scheduling_mode_t& gs_mode);
 };
 
 }  // namespace fastcat

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -252,7 +252,7 @@ bool fastcat::Egd::ConfigFromYamlCommon(YAML::Node node)
   } else {
     // Use mode saved in driver's non-volatile memory.
     jsd_slave_config_.egd.ctrl_gain_scheduling_mode =
-        (jsd_egd_gain_scheduling_mode_t)-1;
+        JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
   }
 
   return true;

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -243,6 +243,18 @@ bool fastcat::Egd::ConfigFromYamlCommon(YAML::Node node)
     return false;
   }
 
+  std::string ctrl_gs_mode_string;
+  if (ParseOptVal(node, "ctrl_gain_scheduling_mode", ctrl_gs_mode_string)) {
+    if (!GSModeFromString(ctrl_gs_mode_string,
+                          jsd_slave_config_.egd.ctrl_gain_scheduling_mode)) {
+      return false;
+    }
+  } else {
+    // Use mode saved in driver's non-volatile memory.
+    jsd_slave_config_.egd.ctrl_gain_scheduling_mode =
+        (jsd_egd_gain_scheduling_mode_t)-1;
+  }
+
   return true;
 }
 
@@ -417,5 +429,25 @@ bool fastcat::Egd::WriteCSMode(DeviceCmd& cmd)
       return false;
     }
   }
+  return true;
+}
+
+bool fastcat::Egd::GSModeFromString(std::string gs_mode_string,
+                                    jsd_egd_gain_scheduling_mode_t& gs_mode)
+{
+  MSG("Converting gain scheduling mode to string.");
+  if (gs_mode_string.compare("DISABLED") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED;
+  } else if (gs_mode_string.compare("SPEED") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_SPEED;
+  } else if (gs_mode_string.compare("POSITION") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_POSITION;
+  } else if (gs_mode_string.compare("MANUAL") == 0) {
+    gs_mode = JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW;
+  } else {
+    ERROR("Gain scheduling mode %s is invalid", gs_mode_string.c_str());
+    return false;
+  }
+
   return true;
 }

--- a/src/jsd/egd.h
+++ b/src/jsd/egd.h
@@ -36,6 +36,8 @@ class Egd : public DeviceBase
  private:
   bool WriteProfiledMode(DeviceCmd& cmd);
   bool WriteCSMode(DeviceCmd& cmd);
+  bool GSModeFromString(std::string                     gs_mode_string,
+                        jsd_egd_gain_scheduling_mode_t& gs_mode);
 };
 
 }  // namespace fastcat

--- a/src/yaml_parser.cc
+++ b/src/yaml_parser.cc
@@ -276,6 +276,17 @@ bool fastcat::ParseOptVal(YAML::Node node, std::string field, double& val)
   return true;
 }
 
+bool fastcat::ParseOptVal(YAML::Node node, std::string field, std::string& val)
+{
+  if (!node[field]) {
+    MSG_DEBUG("Did not find optional string field: %s", field.c_str());
+    return false;
+  }
+  val = node[field].as<std::string>();
+  MSG_DEBUG("Parsed string field %s: %s", field.c_str(), val.c_str());
+  return true;
+}
+
 bool fastcat::ParseOptValCheckRange(YAML::Node node, std::string field,
                                     double& val, double lower, double upper)
 {

--- a/src/yaml_parser.h
+++ b/src/yaml_parser.h
@@ -52,6 +52,7 @@ bool ParseValCheckRange(YAML::Node node, std::string field, uint8_t& val,
 
 // Optional double values
 bool ParseOptVal(YAML::Node node, std::string field, double& val);
+bool ParseOptVal(YAML::Node node, std::string field, std::string& val);
 
 bool ParseOptValCheckRange(YAML::Node node, std::string field, double& val,
                            double lower, double upper);


### PR DESCRIPTION
Summary:
Adds an optional configuration parameter to the egd and actuator's
drivers to allow setting the controller gain scheduling mode before
the EtherCAT device enters operational mode.

Test Plan:
Tested on ROS node communicating with the Elmo motor
controller through the egd and actuator's drivers.

Reviewers: alex-brinkman, JosephBowkett