### PR TITLE
Support gain scheduling in Actuator Fastcat driver.

### DIFF
--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -580,6 +580,11 @@ commands:
     - name: torque_offset_amps
       type: double
 
+  - name: actuator_set_gain_scheduling_index
+    fields:
+    - name: gain_scheduling_index
+      type: uint16_t
+
   - name: actuator_prof_pos
     fields: 
     - name: target_position
@@ -646,6 +651,30 @@ commands:
     - name: mode
       type: int32_t
       comment: UM[1] = 5 by default for pos, vel, and current command modes
+
+  - name: actuator_sdo_disable_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
+
+  - name: actuator_sdo_enable_speed_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
+
+  - name: actuator_sdo_enable_position_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
+
+  - name: actuator_sdo_enable_manual_gain_scheduling
+    fields:
+    - name: dummy
+      type: bool
+      comment: unused
 
   - name: faulter_enable
     fields:

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -356,6 +356,52 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
       }
       break;
 
+    case ACTUATOR_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
+      if (!CheckStateMachineGainSchedulingCmds()) {
+        ERROR("Failed to handle SDO Disable Gain Scheduling Command");
+        return false;
+      }
+      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED);
+      break;
+    }
+
+    case ACTUATOR_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
+      if (!CheckStateMachineGainSchedulingCmds()) {
+        ERROR("Failed to handle SDO Enable Speed Gain Scheduling Command");
+        return false;
+      }
+      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_SPEED);
+      break;
+    }
+
+    case ACTUATOR_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
+      if (!CheckStateMachineGainSchedulingCmds()) {
+        ERROR("Failed to handle SDO Enable Position Gain Scheduling Command");
+        return false;
+      }
+      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_POSITION);
+      break;
+    }
+
+    case ACTUATOR_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD: {
+      if (!CheckStateMachineGainSchedulingCmds()) {
+        ERROR("Failed to handle SDO Enable Manual Gain Scheduling Command");
+        return false;
+      }
+      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW);
+      break;
+    }
+
+    case ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD: {
+      if (!CheckStateMachineGainSchedulingCmds()) {
+        ERROR("Failed to handle Set Gain Scheduling Index Command");
+        return false;
+      }
+      EgdSetGainSchedulingIndex(
+          cmd.actuator_set_gain_scheduling_index_cmd.gain_scheduling_index);
+      break;
+    }
+
     default:
       WARNING("That command type is not supported in this mode!");
       return false;
@@ -622,6 +668,18 @@ void fastcat::Actuator::EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd)
 void fastcat::Actuator::EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd)
 {
   jsd_egd_set_motion_command_cst((jsd_t*)context_, slave_id_, jsd_cst_cmd);
+}
+
+void fastcat::Actuator::EgdSetGainSchedulingMode(
+    jsd_egd_gain_scheduling_mode_t mode)
+{
+  jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode((jsd_t*)context_, slave_id_,
+                                                  mode);
+}
+
+void fastcat::Actuator::EgdSetGainSchedulingIndex(uint16_t index)
+{
+  jsd_egd_set_gain_scheduling_index((jsd_t*)context_, slave_id_, true, index);
 }
 
 bool fastcat::Actuator::GSModeFromString(

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -58,6 +58,7 @@ class Actuator : public DeviceBase
   static std::string StateMachineStateToString(ActuatorStateMachineState sms);
 
   bool CheckStateMachineMotionCmds();
+  bool CheckStateMachineGainSchedulingCmds();
 
   bool HandleNewCSPCmd(DeviceCmd& cmd);
   bool HandleNewCSVCmd(DeviceCmd& cmd);
@@ -94,6 +95,8 @@ class Actuator : public DeviceBase
   virtual void EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd);
   virtual void EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd);
   virtual void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd);
+  virtual void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode);
+  virtual void EgdSetGainSchedulingIndex(uint16_t index);
 
   std::string  actuator_type_str_;
   ActuatorType actuator_type_;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -52,6 +52,33 @@ bool fastcat::Actuator::CheckStateMachineMotionCmds()
   return true;
 }
 
+bool fastcat::Actuator::CheckStateMachineGainSchedulingCmds()
+{
+  switch (actuator_sms_) {
+    case ACTUATOR_SMS_FAULTED:
+    case ACTUATOR_SMS_HALTED:
+    case ACTUATOR_SMS_HOLDING:
+    case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_CS:
+      break;
+
+    case ACTUATOR_SMS_CAL_MOVE_TO_HARDSTOP:
+    case ACTUATOR_SMS_CAL_AT_HARDSTOP:
+    case ACTUATOR_SMS_CAL_MOVE_TO_SOFTSTOP:
+      ERROR("Act %s: %s", name_.c_str(),
+            "Cannot execute gain scheduling commands, calibration is in "
+            "progress");
+      return false;
+
+    default:
+      ERROR("Act %s: %s: %d", name_.c_str(), "Bad Act State ", actuator_sms_);
+      return false;
+  }
+  return true;
+}
+
 bool fastcat::Actuator::HandleNewCSPCmd(DeviceCmd& cmd)
 {
   // Check that the command can be honored within FSM state

--- a/src/jsd/actuator_offline.cc
+++ b/src/jsd/actuator_offline.cc
@@ -51,6 +51,17 @@ void fastcat::ActuatorOffline::EgdSetUnitMode(int32_t mode)
   // no-op
 }
 
+void fastcat::ActuatorOffline::EgdSetGainSchedulingMode(
+    jsd_egd_gain_scheduling_mode_t /* mode */)
+{
+  // no-op
+}
+
+void fastcat::ActuatorOffline::EgdSetGainSchedulingIndex(uint16_t /* index */)
+{
+  // no-op
+}
+
 void fastcat::ActuatorOffline::EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd)
 {
   jsd_egd_state_.cmd_position = jsd_csp_cmd.target_position;

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -26,6 +26,8 @@ class ActuatorOffline : public Actuator
   void EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd) override;
   void EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd) override;
   void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd) override;
+  void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode) override;
+  void EgdSetGainSchedulingIndex(uint16_t index) override;
 };
 
 }  // namespace fastcat


### PR DESCRIPTION
Summary:
Extends the Actuator Fastcat driver to enable the selection of the
gain scheduling strategy for its controller and the selection of
particular gain sets when the strategy is manual scheduling.

Test Plan:
Tested on a ROS node that communicates with the Elmo Gold Drive
motor controller.

Reviewers: alex-brinkman, JosephBowkett