### PR TITLE
Added optional flag to respect absolute encoder positions

### DIFF
--- a/src/device_base.h
+++ b/src/device_base.h
@@ -43,6 +43,8 @@ class DeviceBase
 
   std::vector<Signal> signals_;
 
+  bool actuator_absolute_encoder_ = false; ///< Actuator with absolute encoder
+
  protected:
   std::string name_;         ///< unique device name
   void*       context_;      ///< generic context for JSD

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -164,16 +164,9 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
         JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
   }
 
-  std::string abs_encoder_string;
-  if (ParseOptVal(node, "absolute_encoder", abs_encoder_string)) {
-    if (abs_encoder_string == "true") {
-      absolute_encoder_ = true;
-    }
-    else if (abs_encoder_string != "false") {
-      return false;
-    }
-  } else { // set to false if option is not included
-    absolute_encoder_ = false;
+  if (!ParseOptVal(node, "absolute_encoder", actuator_absolute_encoder_)) {
+    // If we do not find this parameter then set it to false
+    actuator_absolute_encoder_ = false;
   }
 
   // overall_reduction must be set before using EuToCnts/CntsToEu
@@ -495,14 +488,6 @@ void fastcat::Actuator::Reset()
 
 bool fastcat::Actuator::SetOutputPosition(double position)
 {
-  // Exit this function if this actuator has an absolute encoder
-  // we won't update the value from disk
-  if (absolute_encoder_) {
-    MSG("Leaving actuator: %s at absolute encoder position %f", name_.c_str(),
-        state_->actuator_state.actual_position);
-    return true;
-  }
-
   MSG("Act %s: %s%lf %s%lf", name_.c_str(),
       "Changing Position from: ", state_->actuator_state.actual_position,
       "to : ", position);

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -129,6 +129,8 @@ class Actuator : public DeviceBase
 
   bool compute_power_ = false;
 
+  bool absolute_encoder_ = false;
+
   jsd_slave_config_t jsd_slave_config_;
   jsd_egd_state_t    jsd_egd_state_;
 

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -129,8 +129,6 @@ class Actuator : public DeviceBase
 
   bool compute_power_ = false;
 
-  bool absolute_encoder_ = false;
-
   jsd_slave_config_t jsd_slave_config_;
   jsd_egd_state_t    jsd_egd_state_;
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -919,8 +919,8 @@ bool fastcat::Manager::SetActuatorPositions()
     }
     auto find_pos_data = actuator_pos_map_.find(dev_name);
 
-    MSG("Setting actuator: %s to saved pos: %lf", dev_name.c_str(),
-        find_pos_data->second.position);
+    //MSG("Setting actuator: %s to saved pos: %lf", dev_name.c_str(),
+    //    find_pos_data->second.position);
 
     if (!(*device)->SetOutputPosition(find_pos_data->second.position)) {
       ERROR("Failure on SetOutputPosition for device: %s", dev_name.c_str());

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -885,6 +885,12 @@ bool fastcat::Manager::ValidateActuatorPosFile()
     }
     auto find_pos_data = actuator_pos_map_.find(dev_name);
 
+    if ((*device)->actuator_absolute_encoder_ == true) {
+      MSG("Actuator %s has absolute encoder so does not need saved position",
+          dev_name.c_str());
+      continue;
+    }
+
     if (find_pos_data == actuator_pos_map_.end()) {
       if (!actuator_fault_on_missing_pos_file_) {
         WARNING(
@@ -917,10 +923,15 @@ bool fastcat::Manager::SetActuatorPositions()
     if (dev_state->type != ACTUATOR_STATE) {
       continue;
     }
+    
+    if ((*device)->actuator_absolute_encoder_ == true) {
+      continue;
+    }
+    
     auto find_pos_data = actuator_pos_map_.find(dev_name);
 
-    //MSG("Setting actuator: %s to saved pos: %lf", dev_name.c_str(),
-    //    find_pos_data->second.position);
+    MSG("Setting actuator: %s to saved pos: %lf", dev_name.c_str(),
+        find_pos_data->second.position);
 
     if (!(*device)->SetOutputPosition(find_pos_data->second.position)) {
       ERROR("Failure on SetOutputPosition for device: %s", dev_name.c_str());
@@ -941,6 +952,10 @@ void fastcat::Manager::GetActuatorPositions()
     dev_name  = (*device)->GetName();
 
     if (dev_state->type != ACTUATOR_STATE) {
+      continue;
+    }
+
+    if ((*device)->actuator_absolute_encoder_ == true) {
       continue;
     }
 

--- a/src/yaml_parser.cc
+++ b/src/yaml_parser.cc
@@ -287,6 +287,18 @@ bool fastcat::ParseOptVal(YAML::Node node, std::string field, std::string& val)
   return true;
 }
 
+bool fastcat::ParseOptVal(YAML::Node node, std::string field, bool& val)
+{
+  if (!node[field]) {
+    MSG_DEBUG("Did not find optional bool field: %s", field.c_str());
+    return false;
+  }
+  val = node[field].as<bool>();
+  MSG_DEBUG("Parsed bool field %s: %s", field.c_str(),
+            val > 0 ? "true" : "false");
+  return true;
+}
+
 bool fastcat::ParseOptValCheckRange(YAML::Node node, std::string field,
                                     double& val, double lower, double upper)
 {

--- a/src/yaml_parser.h
+++ b/src/yaml_parser.h
@@ -53,6 +53,7 @@ bool ParseValCheckRange(YAML::Node node, std::string field, uint8_t& val,
 // Optional double values
 bool ParseOptVal(YAML::Node node, std::string field, double& val);
 bool ParseOptVal(YAML::Node node, std::string field, std::string& val);
+bool ParseOptVal(YAML::Node node, std::string field, bool& val);
 
 bool ParseOptValCheckRange(YAML::Node node, std::string field, double& val,
                            double lower, double upper);


### PR DESCRIPTION
Daniel, mind taking a look over this code to see if you agree with what it does?

EELS is about to test this on the robot, but it is meant to allow an actuator to ignore any value saved to disk and just read position from an absolute encoder at startup.