### PR TITLE
Make profile pos use current position, last cmd velocity

### DIFF
--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -179,7 +179,7 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
   double target_position = 0;
   if (cmd.actuator_prof_pos_cmd.relative) {
     target_position = cmd.actuator_prof_pos_cmd.target_position +
-                      state_->actuator_state.cmd_position;
+                      state_->actuator_state.actual_position;
   } else {
     target_position = cmd.actuator_prof_pos_cmd.target_position;
   }

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -197,7 +197,7 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
 
   trap_generate(
       &trap_, state_->time,
-      state_->actuator_state.cmd_position,
+      state_->actuator_state.actual_position,
       target_position,
       state_->actuator_state.cmd_velocity,
       cmd.actuator_prof_pos_cmd.end_velocity,
@@ -227,7 +227,7 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
 
   trap_generate_vel(
       &trap_, state_->time,
-      state_->actuator_state.cmd_position,
+      state_->actuator_state.actual_position,
       state_->actuator_state.cmd_velocity,
       cmd.actuator_prof_vel_cmd.target_velocity,
       cmd.actuator_prof_vel_cmd.profile_accel,


### PR DESCRIPTION
We found an issue where using last COMMANDED joint position for profile position commands could cause joints to snap back to their last commanded position if they drifted slightly during operation of other joints (plus at startup last commanded goes back to zero no matter the actual position of the joints.

Solution tested on EELS 1.0 9 module was to use latest ACTUAL position alongside last COMMANDED velocity, which appears to fix both the original problem of 1) velocity constantly resetting back to zero when a stream of profile commands are sent, and the new problem 2) of joints snapping back to last commanded position.