### PR TITLE
Fixes units of jsd_read timeout in Process()

### DIFF
--- a/src/manager.cc
+++ b/src/manager.cc
@@ -208,7 +208,7 @@ bool fastcat::Manager::ConfigFromYaml(YAML::Node node)
 bool fastcat::Manager::Process()
 {
   for (auto it = jsd_map_.begin(); it != jsd_map_.end(); ++it) {
-    jsd_read(it->second, 1e9 / target_loop_rate_hz_);
+    jsd_read(it->second, 1e6 / target_loop_rate_hz_);
   }
 
   // Pass the PDO read time for consistent timestamping before the device Read() 


### PR DESCRIPTION
Sets the EtherCAT cycle period to be the value of the timeout when fetching the EtherCAT frame via the jsd_read function. The underlying SOEM's function, `ecx_receive_processdata` expects the timeout to be in microseconds. The issue was that `Manager::Process` passed a timeout expressed in nanoseconds. Hence, the fix was to express such quantity in microseconds.