### PR TITLE
Hold position after profile position command in actuator driver

### DIFF
--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -194,6 +194,7 @@ Engineering Units (EU) are radians for revolute actuators and meters for linear 
 | `torque_constant`               | OPTIONAL: Torque constant of motor for optional power calculation  |
 | `motor_encoder_gear_ratio`      | OPTIONAL: Capture any gear ratio between the motor and the encoder, i.e. an output encoder  |
 | `ctrl_gain_scheduling_mode`     | OPTIONAL: Gain scheduling mode for the drive's controller: `DISABLED`, `SPEED`, `POSITION`, and `MANUAL`. When not specified, the mode stored in the drive's non-volatile memory is used. |
+| `prof_pos_hold`                 | OPTIONAL: Perform active position control after completion of a position profile command. Useful to mimic brakes on actuators that do not have them. |
 
 ### Implementation Notes
 

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -169,6 +169,12 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
     actuator_absolute_encoder_ = false;
   }
 
+  // Whether position should be actively controlled after a profile position
+  // command is concluded.
+  if (!ParseOptVal(node, "prof_pos_hold", prof_pos_hold_)) {
+    prof_pos_hold_ = false;
+  }
+
   // overall_reduction must be set before using EuToCnts/CntsToEu
   if (actuator_type_ == ACTUATOR_TYPE_REVOLUTE) {
     overall_reduction_ = counts_per_rev_ * gear_ratio_ / (2.0 * M_PI);

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -144,6 +144,8 @@ class Actuator : public DeviceBase
  private:
   bool GSModeFromString(std::string                     gs_mode_string,
                         jsd_egd_gain_scheduling_mode_t& gs_mode);
+
+  bool prof_pos_hold_;
 };
 
 }  // namespace fastcat

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -528,7 +528,7 @@ fastcat::FaultType fastcat::Actuator::ProcessProfPos()
   jsd_cmd.velocity_offset    = EuToCnts(vel);
   jsd_cmd.torque_offset_amps = 0;
 
-  if (!complete) {
+  if (!complete || prof_pos_hold_) {
     EgdCSP(jsd_cmd);
   } else {
     TransitionToState(ACTUATOR_SMS_HOLDING);


### PR DESCRIPTION
Summary:
Implements an optional hold position functionality in the actuator driver. For profile position commands, after reaching the desired position, the driver actively holds the position until other commands are issued. The functionality can be activated through an optional parameter `prof_pos_hold` in the configuration yaml file. Set to true to activate it.
This functionality is useful for actuators without the brakes. It mimics the engagement of the brakes after a position profile is achieved.

Test Plan:
Tested on an Elmo Gold Whistle connected to a DC motor and manually attempting to rotate the shaft after the profile position is achieved.

Reviewers: alex-brinkman, JosephBowkett 