### PR TITLE
Actuator optional limits on actual position

### DIFF
--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -52,6 +52,7 @@ class Actuator : public DeviceBase
   bool VelExceedsCmdLimits(double vel_eu);
   bool AccExceedsCmdLimits(double vel_eu);
   bool CurrentExceedsCmdLimits(double current);
+  bool PosExceedsActualLimits(double pos_eu);
 
   void               RequestStateMachineState(ActuatorStateMachineState sms);
   void               TransitionToState(ActuatorStateMachineState sms);
@@ -114,8 +115,10 @@ class Actuator : public DeviceBase
   double torque_slope_amps_per_sec_     = 0;
   double low_pos_cal_limit_eu_          = 0;
   double low_pos_cmd_limit_eu_          = 0;
+  double low_pos_actual_limit_eu_       = 0.0;
   double high_pos_cmd_limit_eu_         = 0;
   double high_pos_cal_limit_eu_         = 0;
+  double high_pos_actual_limit_eu_      = 0.0;
   double holding_duration_sec_          = 0;
   double egd_brake_engage_msec_         = 0;
   double egd_brake_disengage_msec_      = 0;
@@ -146,6 +149,7 @@ class Actuator : public DeviceBase
                         jsd_egd_gain_scheduling_mode_t& gs_mode);
 
   bool prof_pos_hold_;
+  bool pos_actual_limits_defined_ = false;
 };
 
 }  // namespace fastcat

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -504,6 +504,19 @@ fastcat::FaultType fastcat::Actuator::ProcessHolding()
     return ALL_DEVICE_FAULT;
   }
 
+  if (pos_actual_limits_defined_ &&
+      PosExceedsActualLimits(state_->actuator_state.actual_position)) {
+    // EgdHalt() will be called this cycle, but will take effect the next one.
+    // Shouldn't make much difference.
+    ERROR(
+        "Act %s: Actual position (%lf) is outside limits ([%lf, %lf]), "
+        "faulting. After reset, actuator can be moved back to within limits "
+        "with profile position command.",
+        name_.c_str(), state_->actuator_state.actual_position,
+        low_pos_actual_limit_eu_, high_pos_actual_limit_eu_);
+    return ALL_DEVICE_FAULT;
+  }
+
   if ((state_->time - last_transition_time_) > holding_duration_sec_) {
     EgdHalt();
     TransitionToState(ACTUATOR_SMS_HALTED);
@@ -515,6 +528,29 @@ fastcat::FaultType fastcat::Actuator::ProcessProfPos()
 {
   if (IsMotionFaultConditionMet()) {
     ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+    return ALL_DEVICE_FAULT;
+  }
+
+  // There are two special instances in which the limits on actual position
+  // shall not be checked in ProcessProfPos:
+  // - Calibration. In addition to state ACTUATOR_SMS_PROF_POS, ProcessProfPos
+  // is also called in ACTUATOR_SMS_CAL_MOVE_TO_SOFTSTOP. When in the latter the
+  // limits shall be ignored.
+  // - Ongoing Profile Position processing in which the target position (i.e.
+  // trap_.pos_fini) is within limits. This provides a mechanism to get the
+  // actuator back into nominal operation after a limit violation.
+  if (pos_actual_limits_defined_ &&
+      actuator_sms_ != ACTUATOR_SMS_CAL_MOVE_TO_SOFTSTOP &&
+      PosExceedsActualLimits(state_->actuator_state.actual_position) &&
+      PosExceedsActualLimits(trap_.pos_fini)) {
+    // EgdHalt() will be called this cycle, but will take effect the next one.
+    // Shouldn't make much difference.
+    ERROR(
+        "Act %s: Actual position (%lf) is outside limits ([%lf, %lf]), "
+        "faulting. After reset, actuator can be moved back to within limits "
+        "with profile position command.",
+        name_.c_str(), state_->actuator_state.actual_position,
+        low_pos_actual_limit_eu_, high_pos_actual_limit_eu_);
     return ALL_DEVICE_FAULT;
   }
 
@@ -544,6 +580,19 @@ fastcat::FaultType fastcat::Actuator::ProcessProfVel()
     return ALL_DEVICE_FAULT;
   }
 
+  if (pos_actual_limits_defined_ &&
+      PosExceedsActualLimits(state_->actuator_state.actual_position)) {
+    // EgdHalt() will be called this cycle, but will take effect the next one.
+    // Shouldn't make much difference.
+    ERROR(
+        "Act %s: Actual position (%lf) is outside limits ([%lf, %lf]), "
+        "faulting. After reset, actuator can be moved back to within limits "
+        "with profile position command.",
+        name_.c_str(), state_->actuator_state.actual_position,
+        low_pos_actual_limit_eu_, high_pos_actual_limit_eu_);
+    return ALL_DEVICE_FAULT;
+  }
+
   jsd_egd_motion_command_csv_t jsd_cmd;
 
   double pos_eu, vel;
@@ -570,6 +619,19 @@ fastcat::FaultType fastcat::Actuator::ProcessProfTorque()
     return ALL_DEVICE_FAULT;
   }
 
+  if (pos_actual_limits_defined_ &&
+      PosExceedsActualLimits(state_->actuator_state.actual_position)) {
+    // EgdHalt() will be called this cycle, but will take effect the next one.
+    // Shouldn't make much difference.
+    ERROR(
+        "Act %s: Actual position (%lf) is outside limits ([%lf, %lf]), "
+        "faulting. After reset, actuator can be moved back to within limits "
+        "with profile position command.",
+        name_.c_str(), state_->actuator_state.actual_position,
+        low_pos_actual_limit_eu_, high_pos_actual_limit_eu_);
+    return ALL_DEVICE_FAULT;
+  }
+
   jsd_egd_motion_command_cst_t jsd_cmd;
 
   double dummy_pos_eu, current;
@@ -590,6 +652,19 @@ fastcat::FaultType fastcat::Actuator::ProcessCS()
 {
   if (IsMotionFaultConditionMet()) {
     ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+    return ALL_DEVICE_FAULT;
+  }
+
+  if (pos_actual_limits_defined_ &&
+      PosExceedsActualLimits(state_->actuator_state.actual_position)) {
+    // EgdHalt() will be called this cycle, but will take effect the next one.
+    // Shouldn't make much difference.
+    ERROR(
+        "Act %s: Actual position (%lf) is outside limits ([%lf, %lf]), "
+        "faulting. After reset, actuator can be moved back to within limits "
+        "with profile position command.",
+        name_.c_str(), state_->actuator_state.actual_position,
+        low_pos_actual_limit_eu_, high_pos_actual_limit_eu_);
     return ALL_DEVICE_FAULT;
   }
 


### PR DESCRIPTION
Summary:
Adds optional parameters to specify limits on the actuator's actual position. If the limits are violated, an all-device fault is issued and motion is interrupted as a result.
The actuator can be driven back to within limits through a profile position command with a target position that is within limits. These limits are useful as a safeguard for non-position commands which did not do checks on position, and as a replacement of Elmo-level limits on position feedback which get disabled if the modulo functionality is used (applicable to certain absolute encoders).

Test Plan:
Tested on local network with a motor. Commanded the motor outside the limits and verified the motor is stopped. Verified the motor could be returned to within limits with a profile position command.

Reviewers: alex-brinkman, JosephBowkett