### PR TITLE
passing servo_enabled through fastcat now, updated to fault code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG alex-fault-codes
+    GIT_TAG v1.9.0
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG alex-servo-enable-plus-issue-cleanup
+    GIT_TAG alex-fault-codes
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG v1.8.1
+    GIT_TAG alex-servo-enable-plus-issue-cleanup
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -95,9 +95,11 @@ states:
     - name: cmd_max_current
       type: double
     - name: egd_state_machine_state
-      type: uint8_t
+      type: uint32_t
+      comment: "From jsd_egd_state_machine_state_t"
     - name: egd_mode_of_operation
-      type: uint8_t
+      type: uint32_t
+      comment: "From jsd_egd_mode_of_operation_t"
     - name: sto_engaged
       type: uint8_t
     - name: hall_state
@@ -109,9 +111,10 @@ states:
     - name: servo_enabled
       type: uint8_t
     - name: fault_code
-      type: uint16_t
-    - name: fault_enum
       type: uint32_t 
+      comment: "From jsd_egd_fault_code_t"
+    - name: emcy_error_code
+      type: uint16_t 
     - name: bus_voltage
       type: double
     - name: drive_temperature
@@ -121,7 +124,8 @@ states:
     - name: egd_cmd_position
       type: int32_t
     - name: actuator_state_machine_state
-      type: uint8_t
+      type: uint32_t
+      comment: "From jsd_egd_State_machine_state_t"
     - name: power
       type: double
 
@@ -160,11 +164,11 @@ states:
     - name: cmd_ff_current
       type: double
     - name: actual_state_machine_state
-      type: uint8_t
+      type: uint32_t
+      comment: "From jsd_egd_state_machine_state_t"
     - name: actual_mode_of_operation
-      type: uint8_t
-    - name: async_sdo_in_prog
-      type: bool
+      type: uint32_t
+      comment: "From jsd_egd_mode_of_operation_t"
     - name: sto_engaged
       type: uint8_t
     - name: hall_state
@@ -177,8 +181,13 @@ states:
       type: uint8_t
     - name: motor_on
       type: uint8_t
-    - name: fault_code
+    - name: servo_enabled
       type: uint8_t
+    - name: fault_code
+      type: uint32_t
+      comment: "From jsd_egd_fault_code_t"
+    - name: emcy_error_code
+      type: uint16_t 
     - name: bus_voltage
       type: double
     - name: analog_input_voltage
@@ -504,35 +513,35 @@ commands:
     fields:
     - name: drive_position
       type: int32_t
+    - name: app_id
+      type: uint16_t
 
   - name: egd_sdo_set_unit_mode
     fields:
     - name: unit_mode
       type: int32_t
+    - name: app_id
+      type: uint16_t
 
   - name: egd_sdo_disable_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: egd_sdo_enable_speed_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: egd_sdo_enable_position_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: egd_sdo_enable_manual_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: fts_tare
     fields:
@@ -670,35 +679,33 @@ commands:
       type: double
       comment: Corresponds to the PL[1] or Peak current setting
 
-  - name: actuator_set_unit_mode
+  - name: actuator_sdo_set_unit_mode
     fields:
     - name: mode
       type: int32_t
       comment: UM[1] = 5 by default for pos, vel, and current command modes
+    - name: app_id
+      type: uint16_t
 
   - name: actuator_sdo_disable_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: actuator_sdo_enable_speed_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: actuator_sdo_enable_position_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: actuator_sdo_enable_manual_gain_scheduling
     fields:
-    - name: dummy
-      type: bool
-      comment: unused
+    - name: app_id
+      type: uint16_t
 
   - name: faulter_enable
     fields:

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -106,8 +106,12 @@ states:
       type: uint8_t
     - name: motor_on
       type: uint8_t
-    - name: fault_code
+    - name: servo_enabled
       type: uint8_t
+    - name: fault_code
+      type: uint16_t
+    - name: fault_enum
+      type: uint32_t 
     - name: bus_voltage
       type: double
     - name: drive_temperature

--- a/src/fcgen/types.h.cog
+++ b/src/fcgen/types.h.cog
@@ -166,6 +166,11 @@ typedef struct{
 } ActuatorPosData;
 
 
+typedef struct{
+  jsd_sdo_req_t response;
+  std::string   bus_name;
+} SdoResponse;
+
 } // fastcat namespace
 
 #endif

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -249,23 +249,27 @@ bool fastcat::Actuator::Read()
   state_->actuator_state.cmd_max_current = jsd_egd_state_.cmd_max_current;
 
   state_->actuator_state.egd_state_machine_state =
-      jsd_egd_state_.actual_state_machine_state;
+      static_cast<uint32_t>(jsd_egd_state_.actual_state_machine_state);
   state_->actuator_state.egd_mode_of_operation =
-      jsd_egd_state_.actual_mode_of_operation;
+      static_cast<uint32_t>(jsd_egd_state_.actual_mode_of_operation);
 
-  state_->actuator_state.sto_engaged       = jsd_egd_state_.sto_engaged;
-  state_->actuator_state.hall_state        = jsd_egd_state_.hall_state;
-  state_->actuator_state.target_reached    = jsd_egd_state_.target_reached;
-  state_->actuator_state.motor_on          = jsd_egd_state_.motor_on;
-  state_->actuator_state.servo_enabled     = jsd_egd_state_.servo_enabled;
+  state_->actuator_state.sto_engaged    = jsd_egd_state_.sto_engaged;
+  state_->actuator_state.hall_state     = jsd_egd_state_.hall_state;
+  state_->actuator_state.target_reached = jsd_egd_state_.target_reached;
+  state_->actuator_state.motor_on       = jsd_egd_state_.motor_on;
+  state_->actuator_state.servo_enabled  = jsd_egd_state_.servo_enabled;
+
   state_->actuator_state.faulted =
-      (jsd_egd_state_.fault_enum == JSD_EGD_FAULT_OKAY);
-  state_->actuator_state.fault_code        = jsd_egd_state_.fault_code;
-  state_->actuator_state.fault_enum        = jsd_egd_state_.fault_enum;
+      (jsd_egd_state_.fault_code != JSD_EGD_FAULT_OKAY);
+  state_->actuator_state.fault_code = 
+    static_cast<uint32_t>(jsd_egd_state_.fault_code);
+  state_->actuator_state.emcy_error_code   = jsd_egd_state_.emcy_error_code;
+
   state_->actuator_state.bus_voltage       = jsd_egd_state_.bus_voltage;
   state_->actuator_state.drive_temperature = jsd_egd_state_.drive_temperature;
+
   state_->actuator_state.actuator_state_machine_state =
-      static_cast<int>(actuator_sms_);
+      static_cast<uint32_t>(actuator_sms_);
 
   if (compute_power_) {
     double motor_velocity =
@@ -368,7 +372,7 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
       EgdSetPeakCurrent(peak_current_limit_amps_);
       break;
 
-    case ACTUATOR_SET_UNIT_MODE_CMD:
+    case ACTUATOR_SDO_SET_UNIT_MODE_CMD:
       if (!HandleNewSetUnitModeCmd(cmd)) {
         ERROR("Failed to handle Set Unit Mode Command");
         return false;
@@ -380,7 +384,9 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         ERROR("Failed to handle SDO Disable Gain Scheduling Command");
         return false;
       }
-      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED);
+      EgdSetGainSchedulingMode(
+          JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED,
+          cmd.actuator_sdo_disable_gain_scheduling_cmd.app_id);
       break;
     }
 
@@ -389,7 +395,9 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         ERROR("Failed to handle SDO Enable Speed Gain Scheduling Command");
         return false;
       }
-      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_SPEED);
+      EgdSetGainSchedulingMode(
+          JSD_EGD_GAIN_SCHEDULING_MODE_SPEED,
+          cmd.actuator_sdo_enable_speed_gain_scheduling_cmd.app_id);
       break;
     }
 
@@ -398,7 +406,9 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         ERROR("Failed to handle SDO Enable Position Gain Scheduling Command");
         return false;
       }
-      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_POSITION);
+      EgdSetGainSchedulingMode(
+          JSD_EGD_GAIN_SCHEDULING_MODE_POSITION,
+          cmd.actuator_sdo_enable_position_gain_scheduling_cmd.app_id);
       break;
     }
 
@@ -407,7 +417,9 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         ERROR("Failed to handle SDO Enable Manual Gain Scheduling Command");
         return false;
       }
-      EgdSetGainSchedulingMode(JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW);
+      EgdSetGainSchedulingMode(
+          JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW, 
+          cmd.actuator_sdo_enable_manual_gain_scheduling_cmd.app_id);
       break;
     }
 
@@ -416,7 +428,7 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         ERROR("Failed to handle Set Gain Scheduling Index Command");
         return false;
       }
-      EgdSetGainSchedulingIndex(
+      EgdSetGainSchedulingIndex( 
           cmd.actuator_set_gain_scheduling_index_cmd.gain_scheduling_index);
       break;
     }
@@ -668,10 +680,10 @@ void fastcat::Actuator::EgdSetPeakCurrent(double current)
   jsd_egd_set_peak_current((jsd_t*)context_, slave_id_, current);
 }
 
-void fastcat::Actuator::EgdSetUnitMode(int32_t mode)
+void fastcat::Actuator::EgdSetUnitMode(int32_t mode, uint16_t app_id)
 {
-  MSG("Commanding new UM[1] = %d", mode);
-  jsd_egd_async_sdo_set_unit_mode((jsd_t*)context_, slave_id_, mode);
+  MSG("Commanding new UM[1] = %d app_id = %u", mode, app_id);
+  jsd_egd_async_sdo_set_unit_mode((jsd_t*)context_, slave_id_, mode, app_id);
 }
 
 void fastcat::Actuator::EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd)
@@ -690,15 +702,17 @@ void fastcat::Actuator::EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd)
 }
 
 void fastcat::Actuator::EgdSetGainSchedulingMode(
-    jsd_egd_gain_scheduling_mode_t mode)
+    jsd_egd_gain_scheduling_mode_t mode, 
+    uint16_t app_id)
 {
-  jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode((jsd_t*)context_, slave_id_,
-                                                  mode);
+  jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
+      (jsd_t*)context_, slave_id_, mode, app_id);
 }
 
 void fastcat::Actuator::EgdSetGainSchedulingIndex(uint16_t index)
 {
-  jsd_egd_set_gain_scheduling_index((jsd_t*)context_, slave_id_, true, index);
+  jsd_egd_set_gain_scheduling_index(
+      (jsd_t*)context_, slave_id_, true, index);
 }
 
 bool fastcat::Actuator::GSModeFromString(

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -257,9 +257,11 @@ bool fastcat::Actuator::Read()
   state_->actuator_state.hall_state        = jsd_egd_state_.hall_state;
   state_->actuator_state.target_reached    = jsd_egd_state_.target_reached;
   state_->actuator_state.motor_on          = jsd_egd_state_.motor_on;
+  state_->actuator_state.servo_enabled     = jsd_egd_state_.servo_enabled;
   state_->actuator_state.faulted =
-      (jsd_egd_state_.fault_code == JSD_EGD_FAULT_OKAY);
+      (jsd_egd_state_.fault_enum == JSD_EGD_FAULT_OKAY);
   state_->actuator_state.fault_code        = jsd_egd_state_.fault_code;
+  state_->actuator_state.fault_enum        = jsd_egd_state_.fault_enum;
   state_->actuator_state.bus_voltage       = jsd_egd_state_.bus_voltage;
   state_->actuator_state.drive_temperature = jsd_egd_state_.drive_temperature;
   state_->actuator_state.actuator_state_machine_state =
@@ -268,7 +270,7 @@ bool fastcat::Actuator::Read()
   if (compute_power_) {
     double motor_velocity =
       fabs(state_->actuator_state.actual_velocity) *
-      gear_ratio *
+      gear_ratio_ *
       motor_encoder_gear_ratio_;
     
     double current = fabs(jsd_egd_state_.actual_current);

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -91,11 +91,11 @@ class Actuator : public DeviceBase
   virtual void EgdReset();
   virtual void EgdHalt();
   virtual void EgdSetPeakCurrent(double current);
-  virtual void EgdSetUnitMode(int32_t mode);
+  virtual void EgdSetUnitMode(int32_t mode, uint16_t app_id);
   virtual void EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd);
   virtual void EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd);
   virtual void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd);
-  virtual void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode);
+  virtual void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id);
   virtual void EgdSetGainSchedulingIndex(uint16_t index);
 
   std::string  actuator_type_str_;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -352,7 +352,9 @@ bool fastcat::Actuator::HandleNewSetUnitModeCmd(DeviceCmd& cmd)
       return false;
   }
 
-  EgdSetUnitMode(cmd.actuator_set_unit_mode_cmd.mode);
+  EgdSetUnitMode(
+      cmd.actuator_sdo_set_unit_mode_cmd.mode,
+      cmd.actuator_sdo_set_unit_mode_cmd.app_id);
 
   return true;
 }

--- a/src/jsd/actuator_offline.cc
+++ b/src/jsd/actuator_offline.cc
@@ -45,14 +45,15 @@ void fastcat::ActuatorOffline::EgdSetPeakCurrent(double /* current */)
   // no-op
 }
 
-void fastcat::ActuatorOffline::EgdSetUnitMode(int32_t mode)
+void fastcat::ActuatorOffline::EgdSetUnitMode(int32_t mode, uint16_t app_id)
 {
-  MSG("Commanding new UM[1] = %d", mode);
+  MSG("Commanding new UM[1] = %d app_id = %u", mode, app_id);
   // no-op
 }
 
 void fastcat::ActuatorOffline::EgdSetGainSchedulingMode(
-    jsd_egd_gain_scheduling_mode_t /* mode */)
+    jsd_egd_gain_scheduling_mode_t /* mode */,
+    uint16_t /* app_id */)
 {
   // no-op
 }

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -22,11 +22,11 @@ class ActuatorOffline : public Actuator
   void EgdReset() override;
   void EgdHalt() override;
   void EgdSetPeakCurrent(double current) override;
-  void EgdSetUnitMode(int32_t mode) override;
+  void EgdSetUnitMode(int32_t mode, uint16_t app_id) override;
   void EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd) override;
   void EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd) override;
   void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd) override;
-  void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode) override;
+  void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id) override;
   void EgdSetGainSchedulingIndex(uint16_t index) override;
 };
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -808,6 +808,24 @@ void fastcat::Manager::ExecuteAllDeviceResets()
   faulted_ = false;
 }
 
+bool fastcat::Manager::IsSdoResponseQueueEmpty(){
+  return sdo_response_queue_.empty();
+}
+
+bool fastcat::Manager::PopSdoResponseQueue(SdoResponse& res){
+  if(sdo_response_queue_.empty()){
+    res.bus_name = "INVALID";
+    res.response.success = false;
+    res.response.app_id = 0;
+    return false;
+  }
+
+  res = sdo_response_queue_.front();
+  sdo_response_queue_.pop();
+
+  return true;
+}
+
 bool fastcat::Manager::LoadActuatorPosFile()
 {
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -810,6 +810,28 @@ void fastcat::Manager::ExecuteAllDeviceResets()
 
 bool fastcat::Manager::LoadActuatorPosFile()
 {
+
+  // Look for the existence of at least one actuator in the topology 
+  std::shared_ptr<DeviceState> dev_state;
+  std::string                  dev_name;
+  bool actuators_in_topo = false;
+  for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
+       ++device) {
+    dev_state = (*device)->GetState();
+    dev_name  = (*device)->GetName();
+
+    if (dev_state->type == ACTUATOR_STATE) {
+      actuators_in_topo = true;
+      break;
+    }
+  }
+
+  if(!actuators_in_topo){
+    MSG("No actuators found in topology, bypassing saved positions file functions");
+    return true;
+  }
+
+
   if (!actuator_fault_on_missing_pos_file_) {
     WARNING("YAML parameter \'actuator_fault_on_missing_pos_file\' is FALSE");
     WARNING("\tThis setting is intended for demo and testing and should");

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -813,10 +813,9 @@ bool fastcat::Manager::LoadActuatorPosFile()
 
   // Look for the existence of at least one actuator in the topology 
   bool actuators_in_topo = false;
-  for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
-       ++device) {
-
-    if (dev_state->type == ACTUATOR_STATE) {
+  for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end(); ++device) 
+  {
+    if ((*device)->GetState()->type == ACTUATOR_STATE) {
       actuators_in_topo = true;
       break;
     }

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -812,13 +812,9 @@ bool fastcat::Manager::LoadActuatorPosFile()
 {
 
   // Look for the existence of at least one actuator in the topology 
-  std::shared_ptr<DeviceState> dev_state;
-  std::string                  dev_name;
   bool actuators_in_topo = false;
   for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
        ++device) {
-    dev_state = (*device)->GetState();
-    dev_name  = (*device)->GetName();
 
     if (dev_state->type == ACTUATOR_STATE) {
       actuators_in_topo = true;

--- a/src/manager.h
+++ b/src/manager.h
@@ -137,6 +137,21 @@ class Manager
    */
   void ExecuteAllDeviceFaults();
 
+  /** @brief checks if the SdoResponse Queue is empty
+   *  @return if queue is empty
+   */
+  bool IsSdoResponseQueueEmpty();
+
+  /** @brief get the result of a background SDO operation 
+   *
+   *  If the SDO Response queue contains any responses, this function pops the 
+   *  oldest value and returns it to the application.
+   *
+   *  @return true if the return reference 'res' is valid
+   */
+  bool PopSdoResponseQueue(SdoResponse& res);
+
+
  private:
   bool ConfigJSDBusFromYaml(YAML::Node node);
   bool ConfigFastcatBusFromYaml(YAML::Node node);
@@ -169,6 +184,7 @@ class Manager
   std::vector<DeviceState>                           states_;
   std::map<std::string, ActuatorPosData>             actuator_pos_map_;
   std::unordered_map<std::string, bool>              unique_device_map_;
+  std::queue<SdoResponse>                            sdo_response_queue_;
 };
 }  // namespace fastcat
 


### PR DESCRIPTION
* Makes use of `servo_enabled` flag in JSD
* Uses actuator fault enum more properly
* Adds check for at least one actuator on the bus before looking for saved pos file (closes #45)

- [ ] Merge `jsd/alex-servo-enable-plus-issue-cleanup` first and fix CMakeLists.txt