### PR TITLE
Add LinearInterpolator Device 

### DIFF
--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -1,5 +1,5 @@
 fastcat:
-  target_loop_rate_hz:                1000
+  target_loop_rate_hz:                100
   zero_latency_required:              True
   actuator_position_directory:        /tmp/
   actuator_fault_on_missing_pos_file: False
@@ -220,4 +220,13 @@ buses:
       upper_limit: 0.05
       signals:
       - observed_device_name: pid_1
+        request_signal_name:  output
+
+    - device_class: LinearInterpolation
+      name:         my_lin_interp_1 
+      domain:       [-9, 0, 9]
+      range:        [ 9, 0, 9]
+      enable_out_of_bounds_fault: false
+      signals:
+      - observed_device_name: sig_gen_1
         request_signal_name:  output

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(fastcat STATIC
     fastcat_devices/fts.cc
     fastcat_devices/virtual_fts.cc
     fastcat_devices/faulter.cc
+    fastcat_devices/linear_interpolation.cc
     )
 
 target_include_directories(

--- a/src/fastcat_devices/linear_interpolation.cc
+++ b/src/fastcat_devices/linear_interpolation.cc
@@ -1,0 +1,145 @@
+// Include related header (for cc files)
+#include "fastcat/fastcat_devices/linear_interpolation.h"
+
+// Include c then c++ libraries
+#include <cmath>
+#include <cassert>
+#include <algorithm>
+
+// Include external then project includes
+#include "fastcat/signal_handling.h"
+#include "fastcat/yaml_parser.h"
+#include "jsd/jsd_print.h"
+
+fastcat::LinearInterpolation::LinearInterpolation()
+{
+  state_       = std::make_shared<DeviceState>();
+  state_->type = LINEAR_INTERPOLATION_STATE;
+}
+
+bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node)
+{
+  if (!ParseVal(node, "name", name_)) {
+    return false;
+  }
+  state_->name = name_;
+
+  if (!ParseVal(node, "enable_out_of_bounds_fault", enable_out_of_bounds_fault_)){
+    return false;
+  }
+
+  YAML::Node domain_node;
+  if (!ParseList(node, "domain", domain_node)) {
+    return false;
+  }
+
+  YAML::Node range_node;
+  if (!ParseList(node, "range", range_node)) {
+    return false;
+  }
+
+  if(range_node.size() != domain_node.size()){
+    ERROR("Range size (%zu) and Domain size (%zu) do no match", 
+        range_node.size(), domain_node.size());
+    return false;
+  }
+
+  if(range_node.size() < 2){
+    ERROR("Interpolation Table must consist of at least 2 elements. Provided: (%zu)", 
+        range_node.size());
+    return false;
+  }
+
+  // group together before sorting
+  std::pair<double, double> entry;
+  auto domain_iter = domain_node.begin();
+  auto range_iter = range_node.begin();
+  for(size_t i = 0; i < range_node.size(); i++){
+    entry.first  = domain_iter->as<double>();
+    entry.second = range_iter->as<double>();
+    domain_range_.push_back(entry);
+    domain_iter++;
+    range_iter++;
+  }
+
+  // Finally sort them by increasing domain
+  std::sort(
+    domain_range_.begin(), 
+    domain_range_.end(), 
+    [](auto &lhs, auto &rhs) { 
+      return lhs.first < rhs.first;
+      });
+
+  // And precompute the slope
+  MSG_DEBUG("Interpolation Table (%s)", name_.c_str());
+  MSG_DEBUG("row: domain, range, slope ");
+  size_t i;
+  for(i = 0; i < domain_range_.size()-1; i++){
+    double dy = domain_range_[i+1].second - domain_range_[i].second;
+    double dx = domain_range_[i+1].first  - domain_range_[i].first;
+    if(fabs(dx) < 1e-16){
+      ERROR("Interpolation domain entries are too close (or repeated)");
+      return false;
+    }
+    slope_.push_back(dy/dx);
+
+    MSG_DEBUG("%zu: %lf, %lf, %lf", 
+        i, domain_range_[i].first, domain_range_[i].second, slope_[i]);
+  }
+  MSG_DEBUG("%zu: %lf, %lf, N/A", 
+      i, domain_range_[i].first, domain_range_[i].second);
+
+  if (!ConfigSignalsFromYaml(node, signals_, false)) {
+    return false;
+  }
+  if (signals_.size() != 1) {
+    ERROR("Expecting exactly one signal for LinearInterpolation Device");
+    return false;
+  }
+
+  return true;
+}
+
+
+bool fastcat::LinearInterpolation::Read() {
+
+  // update input signal
+  if (!UpdateSignal(signals_[0])) {
+    ERROR("Could not extract signal");
+    return false;
+  }
+
+  double signal_value = signals_[0].value;
+
+  size_t i;
+  for(i = 0; i < domain_range_.size()-1; i++){
+    if(signal_value < domain_range_[i+1].first){
+      i++;
+      break;
+    }
+  }
+  i--;
+  assert(i < domain_range_.size());
+
+  // Check if extrapolating
+  if( (i == 0) or (i == (domain_range_.size()-1)) ) {
+
+    // Saturate
+    state_->linear_interpolation_state.output = domain_range_[i].second;
+
+    if(enable_out_of_bounds_fault_ and (not device_fault_active_)){
+      ERROR("Linear Interpolation (%s) out of interpolation domain (%g to %g) signal was (%g)", 
+          name_.c_str(), 
+          domain_range_.front().first,
+          domain_range_.back().first,
+          signal_value);
+      return false;
+    }
+  }else{
+
+    // calc linear interpolation output[i] = y[i] + m[i](input[i] - x[i])
+    state_->linear_interpolation_state.output = domain_range_[i].second + 
+      slope_[i]*(signal_value - domain_range_[i].first);
+  }
+  return true;
+}

--- a/src/fastcat_devices/linear_interpolation.cc
+++ b/src/fastcat_devices/linear_interpolation.cc
@@ -116,19 +116,19 @@ bool fastcat::LinearInterpolation::Read() {
   double range_min = domain_range_.front().second;
   double range_max = domain_range_.back().second;
 
-  bool is_out_of_domain = false;
+  state_->linear_interpolation_state.is_saturated = false;
 
   // Check if the input signal is off the interp table
   if(signal_value < domain_min){
     state_->linear_interpolation_state.output = range_min;
-    is_out_of_domain = true;
+    state_->linear_interpolation_state.is_saturated = true;
 
   }else if(signal_value > domain_max){
     state_->linear_interpolation_state.output = range_max;
-    is_out_of_domain = true;
+    state_->linear_interpolation_state.is_saturated = true;
   }
 
-  if(is_out_of_domain) {
+  if(state_->linear_interpolation_state.is_saturated){
 
     // only return false to indicate a NEW fault condition
     if(enable_out_of_bounds_fault_ and (not device_fault_active_)) {

--- a/src/fastcat_devices/linear_interpolation.h
+++ b/src/fastcat_devices/linear_interpolation.h
@@ -23,6 +23,9 @@ class LinearInterpolation: public DeviceBase
   std::vector<std::pair<double, double>> domain_range_;
   bool enable_out_of_bounds_fault_ = false;
 
+  double domain_min_;
+  double domain_max_;
+
   std::vector<double> slope_; // computed during initialization
 };
 

--- a/src/fastcat_devices/linear_interpolation.h
+++ b/src/fastcat_devices/linear_interpolation.h
@@ -23,9 +23,6 @@ class LinearInterpolation: public DeviceBase
   std::vector<std::pair<double, double>> domain_range_;
   bool enable_out_of_bounds_fault_ = false;
 
-  double domain_min_;
-  double domain_max_;
-
   std::vector<double> slope_; // computed during initialization
 };
 

--- a/src/fastcat_devices/linear_interpolation.h
+++ b/src/fastcat_devices/linear_interpolation.h
@@ -1,0 +1,31 @@
+#ifndef FASTCAT_LINEAR_INTERPOLATION_H_
+#define FASTCAT_LINEAR_INTERPOLATION_H_
+
+// Include related header (for cc files)
+
+// Include c then c++ libraries
+
+// Include external then project includes
+#include "fastcat/device_base.h"
+
+namespace fastcat
+{
+
+class LinearInterpolation: public DeviceBase
+{
+ public:
+  LinearInterpolation();
+  bool ConfigFromYaml(YAML::Node node) override;
+  bool Read() override;
+
+ protected:
+  // Config paramters
+  std::vector<std::pair<double, double>> domain_range_;
+  bool enable_out_of_bounds_fault_ = false;
+
+  std::vector<double> slope_; // computed during initialization
+};
+
+}  // namespace fastcat
+
+#endif

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -139,6 +139,13 @@ states:
       comment: "if true, the conditions for faulting are met - 
         on rising edge, the faulter will trigger all devices to fault."
 
+  - name: linear_interpolation
+    fields:
+    - name: output
+      type: double
+    - name: is_saturated
+      type: bool
+
   - name: egd
     fields:
     - name: actual_position

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -25,6 +25,8 @@
 #include "fastcat/fastcat_devices/schmitt_trigger.h"
 #include "fastcat/fastcat_devices/signal_generator.h"
 #include "fastcat/fastcat_devices/virtual_fts.h"
+#include "fastcat/fastcat_devices/linear_interpolation.h"
+
 #include "fastcat/jsd/actuator.h"
 #include "fastcat/jsd/actuator_offline.h"
 #include "fastcat/jsd/ati_fts.h"
@@ -53,6 +55,7 @@
 #include "fastcat/jsd/jed0101_offline.h"
 #include "fastcat/jsd/jed0200.h"
 #include "fastcat/jsd/jed0200_offline.h"
+
 #include "fastcat/signal_handling.h"
 #include "fastcat/yaml_parser.h"
 
@@ -512,6 +515,9 @@ bool fastcat::Manager::ConfigFastcatBusFromYaml(YAML::Node node)
 
     } else if (0 == device_class.compare("Faulter")) {
       device = std::make_shared<Faulter>();
+
+    } else if (0 == device_class.compare("LinearInterpolation")) {
+      device = std::make_shared<LinearInterpolation>();
 
     } else {
       ERROR("Unknown device_class: %s", device_class.c_str());

--- a/test/test_cli.cc
+++ b/test/test_cli.cc
@@ -128,6 +128,11 @@ void print_header(std::vector<fastcat::DeviceState> states)
         fprintf(file, "%s_egd_actual_position, ", state->name.c_str());
         fprintf(file, "%s_egd_cmd_position, ", state->name.c_str());
         break;
+      case fastcat::LINEAR_INTERPOLATION_STATE:
+        fprintf(file, "%s_output, ", state->name.c_str());
+        fprintf(file, "%s_is_saturated, ", state->name.c_str());
+
+        break;
       default:
         break;
     }
@@ -251,6 +256,11 @@ void print_csv_data(std::vector<fastcat::DeviceState> states)
         fprintf(file, "%i, ", state->actuator_state.egd_actual_position);
         fprintf(file, "%i, ", state->actuator_state.egd_cmd_position);
         break;
+      case fastcat::LINEAR_INTERPOLATION_STATE:
+        fprintf(file, "%lf, ", state->linear_interpolation_state.output);
+        fprintf(file, "%u, ", state->linear_interpolation_state.is_saturated);
+        break;
+
       default:
         break;
     }

--- a/test/test_unit/CMakeLists.txt
+++ b/test/test_unit/CMakeLists.txt
@@ -7,6 +7,8 @@ set(TEST_SOURCES
     test_signal_generator.cc
     test_transform_utils.cc
     test_yaml_parser.cc
+    test_linear_interpolation.cc
+
     test_jsd_device_base.cc
     )
 

--- a/test/test_unit/test_linear_interpolation.cc
+++ b/test/test_unit/test_linear_interpolation.cc
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "fastcat/config.h"
+#include "fastcat/fastcat_devices/linear_interpolation.h"
+#include "fastcat/signal_handling.h"
+
+namespace
+{
+class LinearInterpolationTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    base_dir_ = FASTCAT_UNIT_TEST_DIR;
+    base_dir_ += "test_linear_interpolation_yamls/";
+  }
+
+  std::string base_dir_;
+  YAML::Node node_;
+  fastcat::LinearInterpolation device_;
+};
+
+TEST_F(LinearInterpolationTest, InvalidNoName) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_1.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, InvalidNoOutOfBoundsFlag) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_2.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, InvalidSizeMismatch) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_3.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, InvalidTableTooSmall) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_4.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, InvalidRepeated) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_5.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, InvalidManySignals) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_6.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, InvalidNoSignals) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_7.yaml")));
+}
+
+TEST_F(LinearInterpolationTest, ValidSquared) {
+  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid_squared.yaml")));
+
+  EXPECT_FALSE(device_.Read()); // off the interp table
+  device_.Reset();
+
+  device_.signals_[0].value = 10;
+  EXPECT_FALSE(device_.Read()); // off the interp table
+  device_.Reset();
+
+  auto state = device_.GetState();
+
+  device_.signals_[0].value = 1.5;
+  EXPECT_TRUE(device_.Read()); 
+  EXPECT_NEAR(state->linear_interpolation_state.output, pow(1.5, 2), 1.0);
+  
+  device_.signals_[0].value = 2.5;
+  EXPECT_TRUE(device_.Read()); 
+  EXPECT_NEAR(state->linear_interpolation_state.output, pow(2.5, 2), 1.0);
+
+  device_.signals_[0].value = 3.5;
+  EXPECT_TRUE(device_.Read()); 
+  EXPECT_NEAR(state->linear_interpolation_state.output, pow(3.5, 2), 1.0);
+
+  device_.signals_[0].value = 4.5;
+  EXPECT_TRUE(device_.Read()); 
+  EXPECT_NEAR(state->linear_interpolation_state.output, pow(4.5, 2), 1.0);
+
+
+}
+
+
+}  // namespace

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_1.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_1.yaml
@@ -1,0 +1,7 @@
+device_class: LinearInterpolation
+domain:       [1, 2, 3,  4,  5]
+range:        [1, 4, 9, 16, 25]
+enable_out_of_bounds_fault: false
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name:  output

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_2.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_2.yaml
@@ -1,0 +1,7 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1, 2, 3,  4,  5]
+range:        [1, 4, 9, 16, 25]
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name:  output

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_3.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_3.yaml
@@ -1,0 +1,8 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1, 2, 3,  4]
+range:        [1, 4, 9, 16, 25]
+enable_out_of_bounds_fault: false
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name:  output

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_4.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_4.yaml
@@ -1,0 +1,8 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1]
+range:        [1]
+enable_out_of_bounds_fault: false
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name:  output

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_5.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_5.yaml
@@ -1,0 +1,8 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1, 2, 3,  4,  4,  5]
+range:        [1, 4, 9, 16, 16, 25]
+enable_out_of_bounds_fault: false
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name:  output

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_6.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_6.yaml
@@ -1,0 +1,10 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1, 2, 3,  4,  5]
+range:        [1, 4, 9, 16, 25]
+enable_out_of_bounds_fault: false
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name:  output
+- observed_device_name: sig_gen_2
+  request_signal_name:  output

--- a/test/test_unit/test_linear_interpolation_yamls/invalid_7.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/invalid_7.yaml
@@ -1,0 +1,5 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1, 2, 3,  4,  5]
+range:        [1, 4, 9, 16, 25]
+enable_out_of_bounds_fault: false

--- a/test/test_unit/test_linear_interpolation_yamls/valid_abs.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/valid_abs.yaml
@@ -1,7 +1,7 @@
 device_class: LinearInterpolation
 name:         my_lin_interp_1 
-domain:       [1, 2, 3,  4,  5]
-range:        [1, 4, 9, 16, 25]
+domain:       [-30, -20, -10, 0, 10,  20]
+range:        [ 30,  20,  10, 0, 10,  20]
 enable_out_of_bounds_fault: true
 signals:
 - observed_device_name: FIXED_VALUE

--- a/test/test_unit/test_linear_interpolation_yamls/valid_abs_no_error.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/valid_abs_no_error.yaml
@@ -1,0 +1,8 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [-30, -20, -10, 0, 10,  20]
+range:        [ 30,  20,  10, 0, 10,  20]
+enable_out_of_bounds_fault: false
+signals:
+- observed_device_name: FIXED_VALUE
+  fixed_value:          0

--- a/test/test_unit/test_linear_interpolation_yamls/valid_squared.yaml
+++ b/test/test_unit/test_linear_interpolation_yamls/valid_squared.yaml
@@ -1,0 +1,8 @@
+device_class: LinearInterpolation
+name:         my_lin_interp_1 
+domain:       [1, 2, 3,  4,  5]
+range:        [1, 4, 9, 16, 25]
+enable_out_of_bounds_fault: true
+signals:
+- observed_device_name: FIXED_VALUE
+  fixed_value:          0


### PR DESCRIPTION
Adds implementation, test, and documentation for a new Linear Interpolation Fastcat Device

closes #52 

The example updated in `example_config/one_of_every_device_offline.yaml` contains a simple `fabs` interpolation table that observes a sine wave signal and saturates outside the range of `[-9, 9]`. The output of this is shown below:

![image](https://user-images.githubusercontent.com/76965622/196860038-73f85306-55c3-4ce6-8d6f-8a145b03ae6c.png)