### PR TITLE
Feat improve actuator offline

### DIFF
--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -1,5 +1,5 @@
 fastcat:
-  target_loop_rate_hz:                1000
+  target_loop_rate_hz:                100
   zero_latency_required:              True
   actuator_position_directory:        /tmp/
   actuator_fault_on_missing_pos_file: False
@@ -53,8 +53,8 @@ buses:
       high_pos_cmd_limit_eu:            3.14159
       high_pos_cal_limit_eu:            3.2 
       holding_duration_sec:            3.0 # chosen arbitrarily
-      egd_brake_engage_msec:           5
-      egd_brake_disengage_msec:        10
+      egd_brake_engage_msec:           500 
+      egd_brake_disengage_msec:        1000
       egd_crc:                         12345
       egd_drive_max_current_limit:     10 # amps
       smooth_factor:                   0 # default value is 0

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -467,13 +467,22 @@ fastcat::FaultType fastcat::Actuator::Process()
     case ACTUATOR_SMS_PROF_POS:
       retval = ProcessProfPos();
       break;
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
+      retval = ProcessProfPosDisengaging();
+      break;
 
     case ACTUATOR_SMS_PROF_VEL:
       retval = ProcessProfVel();
       break;
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
+      retval = ProcessProfVelDisengaging();
+      break;
 
     case ACTUATOR_SMS_PROF_TORQUE:
       retval = ProcessProfTorque();
+      break;
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
+      retval = ProcessProfTorqueDisengaging();
       break;
 
     case ACTUATOR_SMS_CS:
@@ -637,11 +646,20 @@ std::string fastcat::Actuator::StateMachineStateToString(
     case ACTUATOR_SMS_PROF_POS:
       str = std::string("PROF_POS");
       break;
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
+      str = std::string("PROF_POS_DISENGAGING");
+      break;
     case ACTUATOR_SMS_PROF_VEL:
       str = std::string("PROF_VEL");
       break;
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
+      str = std::string("PROF_VEL_DISENGAGING");
+      break;
     case ACTUATOR_SMS_PROF_TORQUE:
       str = std::string("PROF_TORQUE");
+      break;
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
+      str = std::string("PROF_TORQUE_DISENGAGING");
       break;
     case ACTUATOR_SMS_CS:
       str = std::string("CS");

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -17,8 +17,11 @@ typedef enum {
   ACTUATOR_SMS_HALTED,
   ACTUATOR_SMS_HOLDING,
   ACTUATOR_SMS_PROF_POS,
+  ACTUATOR_SMS_PROF_POS_DISENGAGING,
   ACTUATOR_SMS_PROF_VEL,
+  ACTUATOR_SMS_PROF_VEL_DISENGAGING,
   ACTUATOR_SMS_PROF_TORQUE,
+  ACTUATOR_SMS_PROF_TORQUE_DISENGAGING,
   ACTUATOR_SMS_CS,
   ACTUATOR_SMS_CAL_MOVE_TO_HARDSTOP,
   ACTUATOR_SMS_CAL_AT_HARDSTOP,
@@ -85,6 +88,9 @@ class Actuator : public JsdDeviceBase
   FaultType ProcessCalMoveToHardstop();
   FaultType ProcessCalAtHardstop();
   FaultType ProcessCalMoveToSoftstop();
+  FaultType ProcessProfPosDisengaging();
+  FaultType ProcessProfVelDisengaging();
+  FaultType ProcessProfTorqueDisengaging();
 
   virtual void EgdRead();
   virtual void EgdSetConfig();
@@ -132,6 +138,7 @@ class Actuator : public JsdDeviceBase
 
   jsd_slave_config_t jsd_slave_config_;
   jsd_egd_state_t    jsd_egd_state_;
+  DeviceCmd          last_cmd_;
 
   ActuatorStateMachineState actuator_sms_;
   double                    last_transition_time_;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -29,8 +29,11 @@ bool fastcat::Actuator::CheckStateMachineMotionCmds()
       EgdReset();  // This will open the brake, then fallthrough
     case ACTUATOR_SMS_HOLDING:
     case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
     case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
     case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
     case ACTUATOR_SMS_CS:
       // All of these commands can be safely preempted with CS cmds
       break;
@@ -59,8 +62,11 @@ bool fastcat::Actuator::CheckStateMachineGainSchedulingCmds()
     case ACTUATOR_SMS_HALTED:
     case ACTUATOR_SMS_HOLDING:
     case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
     case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
     case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
     case ACTUATOR_SMS_CS:
       break;
 
@@ -194,6 +200,14 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
     return false;
   }
 
+  // Only transition to disengaging if its needed
+  if(state_->actuator_state.servo_enabled){
+    MSG("Bypassing wait since brakes are disengaged");
+  }else{
+    TransitionToState(ACTUATOR_SMS_PROF_POS_DISENGAGING);
+    last_cmd_ = cmd;
+    return true;
+  }
 
   trap_generate(
       &trap_, state_->time,
@@ -222,6 +236,15 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
     TransitionToState(ACTUATOR_SMS_FAULTED);
     ERROR("Act %s: %s", name_.c_str(), "Failing Prof Vel Command");
     return false;
+  }
+
+  // Only transition to disengaging if its needed
+  if(state_->actuator_state.servo_enabled){
+    MSG("Bypassing wait since brakes are disengaged");
+  }else{
+    TransitionToState(ACTUATOR_SMS_PROF_VEL_DISENGAGING);
+    last_cmd_ = cmd;
+    return true;
   }
 
 
@@ -253,6 +276,14 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
     return false;
   }
 
+  // Only transition to disengaging if its needed
+  if(state_->actuator_state.servo_enabled){
+    MSG("Bypassing wait since brakes are disengaged");
+  }else{
+    TransitionToState(ACTUATOR_SMS_PROF_VEL_DISENGAGING);
+    last_cmd_ = cmd;
+    return true;
+  }
 
   trap_generate_vel(
       &trap_, state_->time, 0, 0, cmd.actuator_prof_torque_cmd.target_torque_amps,
@@ -278,8 +309,11 @@ bool fastcat::Actuator::HandleNewHaltCmd()
 
     case ACTUATOR_SMS_HOLDING:
     case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
     case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
     case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
     case ACTUATOR_SMS_CS:
     case ACTUATOR_SMS_CAL_MOVE_TO_HARDSTOP:
     case ACTUATOR_SMS_CAL_AT_HARDSTOP:
@@ -306,8 +340,11 @@ bool fastcat::Actuator::HandleNewSetOutputPositionCmd(DeviceCmd& cmd)
       break;
 
     case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
     case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
     case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
     case ACTUATOR_SMS_CS:
     case ACTUATOR_SMS_CAL_MOVE_TO_HARDSTOP:
     case ACTUATOR_SMS_CAL_AT_HARDSTOP:
@@ -337,8 +374,11 @@ bool fastcat::Actuator::HandleNewSetUnitModeCmd(DeviceCmd& cmd)
       break;
 
     case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
     case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
     case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
     case ACTUATOR_SMS_CS:
     case ACTUATOR_SMS_CAL_MOVE_TO_HARDSTOP:
     case ACTUATOR_SMS_CAL_AT_HARDSTOP:
@@ -374,8 +414,11 @@ bool fastcat::Actuator::HandleNewCalibrationCmd(DeviceCmd& cmd)
     case ACTUATOR_SMS_HOLDING:
       break;
     case ACTUATOR_SMS_PROF_POS:
+    case ACTUATOR_SMS_PROF_POS_DISENGAGING:
     case ACTUATOR_SMS_PROF_VEL:
+    case ACTUATOR_SMS_PROF_VEL_DISENGAGING:
     case ACTUATOR_SMS_PROF_TORQUE:
+    case ACTUATOR_SMS_PROF_TORQUE_DISENGAGING:
     case ACTUATOR_SMS_CS:
       TransitionToState(ACTUATOR_SMS_FAULTED);
       ERROR("Act %s: %s", name_.c_str(),
@@ -697,4 +740,130 @@ fastcat::FaultType fastcat::Actuator::ProcessCalAtHardstop()
 fastcat::FaultType fastcat::Actuator::ProcessCalMoveToSoftstop()
 {
   return ProcessProfPos();
+}
+
+fastcat::FaultType fastcat::Actuator::ProcessProfPosDisengaging()
+{
+  if (IsMotionFaultConditionMet()) {
+    ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+    return ALL_DEVICE_FAULT;
+  }
+
+  double target_position = 0;
+  if (last_cmd_.actuator_prof_pos_cmd.relative) {
+    target_position = last_cmd_.actuator_prof_pos_cmd.target_position +
+                      state_->actuator_state.actual_position;
+  } else {
+    target_position = last_cmd_.actuator_prof_pos_cmd.target_position;
+  }
+
+  if(state_->actuator_state.servo_enabled){
+    // If brakes are disengaged, setup the traps and transition to the execution state
+    trap_generate(
+        &trap_, state_->time,
+        state_->actuator_state.actual_position,
+        target_position,
+        state_->actuator_state.cmd_velocity,
+        last_cmd_.actuator_prof_pos_cmd.end_velocity,
+        last_cmd_.actuator_prof_pos_cmd.profile_velocity, // consider abs()
+        last_cmd_.actuator_prof_pos_cmd.profile_accel);
+
+    TransitionToState(ACTUATOR_SMS_PROF_POS);
+
+  }else{
+    // Otherwise, command the current position to trigger the transition and wait
+
+    jsd_egd_motion_command_csp_t jsd_cmd;
+
+    jsd_cmd.target_position    = PosEuToCnts(state_->actuator_state.actual_position);
+    jsd_cmd.position_offset    = 0;
+    jsd_cmd.velocity_offset    = 0;
+    jsd_cmd.torque_offset_amps = 0;
+
+    EgdCSP(jsd_cmd);
+
+    // Check runout timer here, brake engage/disengage time cannot exceed 1 second
+    // per MAN-G-CR Section BP - Brake Parameters
+    if( (jsd_get_time_sec() - last_transition_time_) > (1.0 + 2*loop_period_)){
+      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting", name_.c_str());
+      return ALL_DEVICE_FAULT;
+    }
+  }
+
+  return NO_FAULT;
+}
+
+fastcat::FaultType fastcat::Actuator::ProcessProfVelDisengaging()
+{
+  if (IsMotionFaultConditionMet()) {
+    ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+    return ALL_DEVICE_FAULT;
+  }
+
+  if(state_->actuator_state.servo_enabled){
+    // If brakes are disengaged, setup the traps and transition to the execution state
+  trap_generate_vel(
+      &trap_, state_->time,
+      state_->actuator_state.actual_position,
+      state_->actuator_state.cmd_velocity,
+      last_cmd_.actuator_prof_vel_cmd.target_velocity,
+      last_cmd_.actuator_prof_vel_cmd.profile_accel,
+      last_cmd_.actuator_prof_vel_cmd.max_duration);
+
+  TransitionToState(ACTUATOR_SMS_PROF_VEL);
+
+  }else{
+    // Otherwise, command the current position to trigger the transition and wait
+    jsd_egd_motion_command_csv_t jsd_cmd;
+
+    jsd_cmd.target_velocity    = 0;
+    jsd_cmd.velocity_offset    = 0;
+    jsd_cmd.torque_offset_amps = 0;
+
+    EgdCSV(jsd_cmd);
+
+    // Check runout timer here, brake engage/disengage time cannot exceed 1 second
+    // per MAN-G-CR Section BP - Brake Parameters
+    if( (jsd_get_time_sec() - last_transition_time_) > (1.0 + 2*loop_period_)){
+      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting", name_.c_str());
+      return ALL_DEVICE_FAULT;
+    }
+  }
+
+  return NO_FAULT;
+}
+
+fastcat::FaultType fastcat::Actuator::ProcessProfTorqueDisengaging()
+{
+  if (IsMotionFaultConditionMet()) {
+    ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+    return ALL_DEVICE_FAULT;
+  }
+
+  if(state_->actuator_state.servo_enabled){
+    // If brakes are disengaged, setup the traps and transition to the execution state
+    trap_generate_vel(
+        &trap_, state_->time, 0, 0, last_cmd_.actuator_prof_torque_cmd.target_torque_amps,
+        torque_slope_amps_per_sec_, last_cmd_.actuator_prof_torque_cmd.max_duration);
+
+    TransitionToState(ACTUATOR_SMS_PROF_TORQUE);
+
+  }else{
+    // Otherwise, command the current position to trigger the transition and wait
+    jsd_egd_motion_command_cst_t jsd_cmd;
+
+    jsd_cmd.target_torque_amps = 0;
+    jsd_cmd.torque_offset_amps = 0;
+
+    EgdCST(jsd_cmd);
+
+    // Check runout timer here, brake engage/disengage time cannot exceed 1 second
+    // per MAN-G-CR Section BP - Brake Parameters
+    if( (jsd_get_time_sec() - last_transition_time_) > (1.0 + 2*loop_period_)){
+      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting", name_.c_str());
+      return ALL_DEVICE_FAULT;
+    }
+  }
+
+  return NO_FAULT;
 }

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -28,6 +28,9 @@ class ActuatorOffline : public Actuator
   void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd) override;
   void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id) override;
   void EgdSetGainSchedulingIndex(uint16_t index) override;
+
+  double motor_on_start_time_;
+  uint8_t last_motor_on_state_;
 };
 
 }  // namespace fastcat

--- a/test/test_cli.cc
+++ b/test/test_cli.cc
@@ -127,6 +127,9 @@ void print_header(std::vector<fastcat::DeviceState> states)
         fprintf(file, "%s_target_reached, ", state->name.c_str());
         fprintf(file, "%s_egd_actual_position, ", state->name.c_str());
         fprintf(file, "%s_egd_cmd_position, ", state->name.c_str());
+
+        fprintf(file, "%s_motor_on, ",  state->name.c_str());
+        fprintf(file, "%s_servo_enabled, ", state->name.c_str());
         break;
       default:
         break;
@@ -250,6 +253,9 @@ void print_csv_data(std::vector<fastcat::DeviceState> states)
 
         fprintf(file, "%i, ", state->actuator_state.egd_actual_position);
         fprintf(file, "%i, ", state->actuator_state.egd_cmd_position);
+
+        fprintf(file, "%u, ", state->actuator_state.motor_on);
+        fprintf(file, "%u, ", state->actuator_state.servo_enabled);
         break;
       default:
         break;


### PR DESCRIPTION
* Offline Actuator devices will emulate `motor_on` and `servo_enabled` state variables now
* Actuator Prof Pos/Vel/torque commands will now wait until the brakes are disengaged before starting motion.

Closes #55 and #54 