### PR TITLE
Feat clear error on reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG feat-clear-error-on-reset
+    GIT_TAG v2.1.0
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG v2.0.0
+    GIT_TAG feat-clear-error-on-reset
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -523,6 +523,8 @@ void fastcat::Actuator::Reset()
 {
   WARNING("Resetting Actuator device %s", name_.c_str());
   if (actuator_sms_ == ACTUATOR_SMS_FAULTED) {
+    // Resetting here would open brakes so we explicitly do not reset the EGD
+    // and instead wait until the next transition out of HALTED is requested.
     //EgdReset();
     TransitionToState(ACTUATOR_SMS_HALTED);
   }

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -526,6 +526,8 @@ void fastcat::Actuator::Reset()
     // Resetting here would open brakes so we explicitly do not reset the EGD
     // and instead wait until the next transition out of HALTED is requested.
     //EgdReset();
+    // but we can and need to clear errors
+    EgdClearErrors();
     TransitionToState(ACTUATOR_SMS_HALTED);
   }
 }
@@ -698,10 +700,15 @@ void fastcat::Actuator::EgdProcess()
   jsd_egd_process((jsd_t*)context_, slave_id_);
 }
 
+void fastcat::Actuator::EgdClearErrors()
+{
+  jsd_egd_clear_errors((jsd_t*)context_, slave_id_);
+}
+
 void fastcat::Actuator::EgdReset()
 {
-    MSG("Resetting EGD through JSD: %s", name_.c_str());
-    jsd_egd_reset((jsd_t*)context_, slave_id_);
+  MSG("Resetting EGD through JSD: %s", name_.c_str());
+  jsd_egd_reset((jsd_t*)context_, slave_id_);
 }
 
 void fastcat::Actuator::EgdHalt() { jsd_egd_halt((jsd_t*)context_, slave_id_); }

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -524,9 +524,7 @@ void fastcat::Actuator::Reset()
   WARNING("Resetting Actuator device %s", name_.c_str());
   if (actuator_sms_ == ACTUATOR_SMS_FAULTED) {
     // Resetting here would open brakes so we explicitly do not reset the EGD
-    // and instead wait until the next transition out of HALTED is requested.
-    //EgdReset();
-    // but we can and need to clear errors
+    // and instead only clear latched errors 
     EgdClearErrors();
     TransitionToState(ACTUATOR_SMS_HALTED);
   }

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -95,6 +95,7 @@ class Actuator : public JsdDeviceBase
   virtual void EgdRead();
   virtual void EgdSetConfig();
   virtual void EgdProcess();
+  virtual void EgdClearErrors();
   virtual void EgdReset();
   virtual void EgdHalt();
   virtual void EgdSetPeakCurrent(double current);

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -535,10 +535,14 @@ fastcat::FaultType fastcat::Actuator::ProcessFaulted()
 
 fastcat::FaultType fastcat::Actuator::ProcessHalted()
 {
-  if (IsIdleFaultConditionMet()) {
-    ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
-    return ALL_DEVICE_FAULT;
-  }
+  //  Invoking a RESET will fail the following fault condition since the 
+  //  fault_code and emcy_error_code will contain the last-tripped fault information.
+  //  Currently, the only way for JSD to clear these codes is to call `EgdReset();
+  //
+  //if (IsIdleFaultConditionMet()) {
+  //  ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+  //  return ALL_DEVICE_FAULT;
+  //}
 
   return NO_FAULT;
 }

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -535,15 +535,10 @@ fastcat::FaultType fastcat::Actuator::ProcessFaulted()
 
 fastcat::FaultType fastcat::Actuator::ProcessHalted()
 {
-  //  Invoking a RESET will fail the following fault condition since the 
-  //  fault_code and emcy_error_code will contain the last-tripped fault information.
-  //  Currently, the only way for JSD to clear these codes is to call `EgdReset();
-  //
-  //if (IsIdleFaultConditionMet()) {
-  //  ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
-  //  return ALL_DEVICE_FAULT;
-  //}
-
+  if (IsIdleFaultConditionMet()) {
+    ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
+    return ALL_DEVICE_FAULT;
+  }
   return NO_FAULT;
 }
 

--- a/src/jsd/actuator_offline.cc
+++ b/src/jsd/actuator_offline.cc
@@ -64,6 +64,11 @@ void fastcat::ActuatorOffline::EgdProcess()
   }
 }
 
+void fastcat::ActuatorOffline::EgdClearErrors()
+{
+  // no-op
+}
+
 void fastcat::ActuatorOffline::EgdReset()
 {
   // no-op

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -19,6 +19,7 @@ class ActuatorOffline : public Actuator
   void EgdRead() override;
   void EgdSetConfig() override;
   void EgdProcess() override;
+  void EgdClearErrors() override;
   void EgdReset() override;
   void EgdHalt() override;
   void EgdSetPeakCurrent(double current) override;


### PR DESCRIPTION
Makes use of the new `jsd_egd_clear_errors` to help reset function work as desired. 

- [ ] fix the CMakeLists.txt once the JSD version tag is released
bump minor version