### PR TITLE
Fastcat manager interface to expose actuator name/param

### DIFF
--- a/src/device_base.cc
+++ b/src/device_base.cc
@@ -47,34 +47,3 @@ void fastcat::DeviceBase::Reset()
 }
 
 fastcat::FaultType fastcat::DeviceBase::Process() { return NO_FAULT; }
-
-double fastcat::DeviceBase::GetActPosMax() {
-  ERROR("GetActPosMax not defined for Device: %s", name_.c_str());
-  return 0.0;
-}
-
-double fastcat::DeviceBase::GetActPosMin() {
-  ERROR("GetActPosMin not defined for Device: %s", name_.c_str());
-  return 0.0;
-}
-
-double fastcat::DeviceBase::GetActVelMax() {
-  ERROR("GetActVelMax not defined for Device: %s", name_.c_str());
-  return 0.0;
-}
-
-double fastcat::DeviceBase::GetActAccMax() {
-  ERROR("GetActAccMax not defined for Device: %s", name_.c_str());
-  return 0.0;
-}
-
-double fastcat::DeviceBase::GetActCurPeak() {
-  ERROR("GetActCurPeak not defined for Device: %s", name_.c_str());
-  return 0.0;
-}
-
-double fastcat::DeviceBase::GetActCurCont() {
-  ERROR("GetActCurCont not defined for Device: %s", name_.c_str());
-  return 0.0;
-}
-

--- a/src/device_base.cc
+++ b/src/device_base.cc
@@ -61,3 +61,34 @@ bool fastcat::DeviceBase::SetOutputPosition(double /* position */)
   return false;
 }
 
+double fastcat::DeviceBase::GetActPosMax() {
+  ERROR("GetActPosMax not defined for Device: %s", name_.c_str());
+  return 0.0;
+}
+
+double fastcat::DeviceBase::GetActPosMin() {
+  ERROR("GetActPosMin not defined for Device: %s", name_.c_str());
+  return 0.0;
+}
+
+double fastcat::DeviceBase::GetActVelMax() {
+  ERROR("GetActVelMax not defined for Device: %s", name_.c_str());
+  return 0.0;
+}
+
+double fastcat::DeviceBase::GetActAccMax() {
+  ERROR("GetActAccMax not defined for Device: %s", name_.c_str());
+  return 0.0;
+}
+
+double fastcat::DeviceBase::GetActCurPeak() {
+  ERROR("GetActCurPeak not defined for Device: %s", name_.c_str());
+  return 0.0;
+}
+
+double fastcat::DeviceBase::GetActCurCont() {
+  ERROR("GetActCurCont not defined for Device: %s", name_.c_str());
+  return 0.0;
+}
+
+

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -21,13 +21,20 @@ class DeviceBase
   // Pure virtual methods
   virtual bool ConfigFromYaml(YAML::Node node) = 0;
   virtual bool Read()                          = 0;
-
+  
   // Non-pure virtual methods with default implementation
   virtual FaultType Process();
   virtual bool      Write(DeviceCmd& cmd);
   virtual void      Fault();
   virtual void      Reset();
   virtual bool      SetOutputPosition(double position);
+  
+  virtual double    GetActPosMax();
+  virtual double    GetActPosMin();
+  virtual double    GetActVelMax();  
+  virtual double    GetActAccMax();
+  virtual double    GetActCurPeak();
+  virtual double    GetActCurCont();
 
   // non-virtual methods
   void RegisterCmdQueue(std::shared_ptr<std::queue<DeviceCmd>> cmd_queue);

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -28,13 +28,6 @@ class DeviceBase
   virtual void      Fault();
   virtual void      Reset();
   
-  virtual double    GetActPosMax();
-  virtual double    GetActPosMin();
-  virtual double    GetActVelMax();  
-  virtual double    GetActAccMax();
-  virtual double    GetActCurPeak();
-  virtual double    GetActCurCont();
-
   // non-virtual methods
   void RegisterCmdQueue(std::shared_ptr<std::queue<DeviceCmd>> cmd_queue);
   std::string                  GetName();

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -541,30 +541,30 @@ bool fastcat::Actuator::SetOutputPosition(double position)
   return true;
 }
 
-double fastcat::Actuator::GetActPosMax()
+double fastcat::Actuator::GetHighPosCmdLimit()
 {
   return high_pos_cmd_limit_eu_;
 }
-double fastcat::Actuator::GetActPosMin()
+double fastcat::Actuator::GetLowPosCmdLimit()
 {
   return low_pos_cmd_limit_eu_;
 }
-double fastcat::Actuator::GetActVelMax()
+double fastcat::Actuator::GetMaxSpeed()
 {
   return max_speed_eu_per_sec_;
 }
-double fastcat::Actuator::GetActAccMax()
+double fastcat::Actuator::GetMaxAccel()
 {
   return max_accel_eu_per_sec2_;
 }
-double fastcat::Actuator::GetActCurPeak()
+double fastcat::Actuator::GetPeakCurLimit()
 {
   return peak_current_limit_amps_;
 }
-double fastcat::Actuator::GetActCurCont()
+double fastcat::Actuator::GetContCurLimit()
 {
   return continuous_current_limit_amps_;
-
+}
 bool fastcat::Actuator::HasAbsoluteEncoder()
 {
   return actuator_absolute_encoder_;

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -503,6 +503,31 @@ bool fastcat::Actuator::SetOutputPosition(double position)
   return true;
 }
 
+double fastcat::Actuator::GetActPosMax()
+{
+  return high_pos_cmd_limit_eu_;
+}
+double fastcat::Actuator::GetActPosMin()
+{
+  return low_pos_cmd_limit_eu_;
+}
+double fastcat::Actuator::GetActVelMax()
+{
+  return max_speed_eu_per_sec_;
+}
+double fastcat::Actuator::GetActAccMax()
+{
+  return max_accel_eu_per_sec2_;
+}
+double fastcat::Actuator::GetActCurPeak()
+{
+  return peak_current_limit_amps_;
+}
+double fastcat::Actuator::GetActCurCont()
+{
+  return continuous_current_limit_amps_;
+}
+
 double fastcat::Actuator::CntsToEu(int32_t cnts)
 {
   return cnts / overall_reduction_;

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -46,12 +46,12 @@ class Actuator : public JsdDeviceBase
   bool      SetOutputPosition(double position);
   bool      HasAbsoluteEncoder();
 
-  double    GetActPosMax() override;
-  double    GetActPosMin() override;
-  double    GetActVelMax() override;
-  double    GetActAccMax() override;
-  double    GetActCurPeak() override;
-  double    GetActCurCont() override;
+  double    GetHighPosCmdLimit();
+  double    GetLowPosCmdLimit();
+  double    GetMaxSpeed();
+  double    GetMaxAccel();
+  double    GetPeakCurLimit();
+  double    GetContCurLimit();
 
  protected:
   double  CntsToEu(int32_t cnts);

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -9,6 +9,7 @@
 #include "fastcat/jsd/jsd_device_base.h"
 #include "fastcat/trap.h"
 #include "jsd/jsd_egd_pub.h"
+#include "jsd/jsd_time.h"
 
 namespace fastcat
 {

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -42,6 +42,13 @@ class Actuator : public DeviceBase
   void      Reset() override;
   bool      SetOutputPosition(double position) override;
 
+  double    GetActPosMax() override;
+  double    GetActPosMin() override;
+  double    GetActVelMax() override;
+  double    GetActAccMax() override;
+  double    GetActCurPeak() override;
+  double    GetActCurCont() override;
+
  protected:
   double  CntsToEu(int32_t cnts);
   int32_t EuToCnts(double eu);

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -335,7 +335,7 @@ fastcat::Manager::GetDeviceStatePointers()
 
 double fastcat::Manager::GetTargetLoopRate() { return target_loop_rate_hz_; }
 
-void fastcat::Manager::GetActuatorsName(std::vector<std::string>& names)
+void fastcat::Manager::GetActuatorsName(std::vector<std::string> &names)
 {
   std::shared_ptr<DeviceState> dev_state;
   std::string                  dev_name;
@@ -351,12 +351,12 @@ void fastcat::Manager::GetActuatorsName(std::vector<std::string>& names)
   }  
 }
 
-void fastcat::Manager::GetActuatorsParams(std::vector<std::vector<std::double>>& params)
+void fastcat::Manager::GetActuatorsParams(std::vector<std::shared_ptr<std::vector<double>>> &params)
 {
   std::shared_ptr<DeviceState> dev_state;
   std::string                  dev_name;
   std::shared_ptr<Actuator>    actuator;  
-  std::vector<double>          act_params;
+  std::shared_ptr<std::vector<double>> act_params;
   
   params.clear();
   for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
@@ -370,13 +370,13 @@ void fastcat::Manager::GetActuatorsParams(std::vector<std::vector<std::double>>&
 
     actuator = std::dynamic_pointer_cast<Actuator>(*device);
 
-    act_pact_paramsaram.clear();
-    act_params.push_back(actuator->GetHighPosCmdLimit());    
-    act_params.push_back(actuator->GetLowPosCmdLimit());    
-    act_params.push_back(actuator->GetMaxSpeed());    
-    act_params.push_back(actuator->GetMaxAccel());    
-    act_params.push_back(actuator->GetPeakCurLimit());    
-    act_params.push_back(actuator->GetContCurLimit());    
+    act_params->clear();
+    act_params->push_back(actuator->GetHighPosCmdLimit());    
+    act_params->push_back(actuator->GetLowPosCmdLimit());    
+    act_params->push_back(actuator->GetMaxSpeed());    
+    act_params->push_back(actuator->GetMaxAccel());    
+    act_params->push_back(actuator->GetPeakCurLimit());    
+    act_params->push_back(actuator->GetContCurLimit());    
     params.push_back(act_params);
   }    
 }

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -355,9 +355,10 @@ void fastcat::Manager::GetActuatorsParams(std::vector<std::shared_ptr<std::vecto
 {
   std::shared_ptr<DeviceState> dev_state;
   std::string                  dev_name;
-  std::shared_ptr<Actuator>    actuator;  
-  std::shared_ptr<std::vector<double>> act_params;
+  std::shared_ptr<Actuator>    actuator;    
+  std::vector<double> act_params;
   
+  MSG("Debug, starting to get act params");
   params.clear();
   for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
        ++device){        
@@ -370,14 +371,15 @@ void fastcat::Manager::GetActuatorsParams(std::vector<std::shared_ptr<std::vecto
 
     actuator = std::dynamic_pointer_cast<Actuator>(*device);
 
-    act_params->clear();
-    act_params->push_back(actuator->GetHighPosCmdLimit());    
-    act_params->push_back(actuator->GetLowPosCmdLimit());    
-    act_params->push_back(actuator->GetMaxSpeed());    
-    act_params->push_back(actuator->GetMaxAccel());    
-    act_params->push_back(actuator->GetPeakCurLimit());    
-    act_params->push_back(actuator->GetContCurLimit());    
-    params.push_back(act_params);
+    MSG("high pos cmd limit: %f", actuator->GetHighPosCmdLimit());
+    act_params.clear();
+    act_params.push_back(actuator->GetHighPosCmdLimit());    
+    act_params.push_back(actuator->GetLowPosCmdLimit());    
+    act_params.push_back(actuator->GetMaxSpeed());    
+    act_params.push_back(actuator->GetMaxAccel());    
+    act_params.push_back(actuator->GetPeakCurLimit());    
+    act_params.push_back(actuator->GetContCurLimit());    
+    params.push_back(std::make_shared<std::vector<double>>(act_params));
   }    
 }
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -335,30 +335,30 @@ fastcat::Manager::GetDeviceStatePointers()
 
 double fastcat::Manager::GetTargetLoopRate() { return target_loop_rate_hz_; }
 
-std::vector<std::string> fastcat::Manager::GetActuatorsName()
+void fastcat::Manager::GetActuatorsName(std::vector<std::string>& names)
 {
   std::shared_ptr<DeviceState> dev_state;
   std::string                  dev_name;
-  std::vector<std::string> acts_name;
+  names.clear();  
   for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
        ++device){        
     dev_state = (*device)->GetState();
     dev_name  = (*device)->GetName();
 
     if (dev_state->type == ACTUATOR_STATE) {
-      acts_name.push_back(dev_name);      
+      names.push_back(dev_name);      
     }
-  }
-  return acts_name;  
+  }  
 }
 
-std::vector<std::vector<double>> fastcat::Manager::GetActuatorsParam()
+void fastcat::Manager::GetActuatorsParams(std::vector<std::vector<std::double>>& params)
 {
   std::shared_ptr<DeviceState> dev_state;
   std::string                  dev_name;
-  std::vector<std::vector<double>> acts_param;  
-  std::vector<double>          act_param;
-  std::vector<double>          pos_min;
+  std::shared_ptr<Actuator>    actuator;  
+  std::vector<double>          act_params;
+  
+  params.clear();
   for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
        ++device){        
     dev_state = (*device)->GetState();
@@ -367,17 +367,18 @@ std::vector<std::vector<double>> fastcat::Manager::GetActuatorsParam()
     if (dev_state->type != ACTUATOR_STATE) {
       continue;
     }
-    MSG("For act: %s", dev_name.c_str());
-    act_param.clear();
-    act_param.push_back((*device)->GetActPosMax());    
-    act_param.push_back((*device)->GetActPosMin());
-    act_param.push_back((*device)->GetActVelMax());
-    act_param.push_back((*device)->GetActAccMax());
-    act_param.push_back((*device)->GetActCurPeak());
-    act_param.push_back((*device)->GetActCurCont());    
-    acts_param.push_back(act_param);
-  }
-  return acts_param;  
+
+    actuator = std::dynamic_pointer_cast<Actuator>(*device);
+
+    act_pact_paramsaram.clear();
+    act_params.push_back(actuator->GetHighPosCmdLimit());    
+    act_params.push_back(actuator->GetLowPosCmdLimit());    
+    act_params.push_back(actuator->GetMaxSpeed());    
+    act_params.push_back(actuator->GetMaxAccel());    
+    act_params.push_back(actuator->GetPeakCurLimit());    
+    act_params.push_back(actuator->GetContCurLimit());    
+    params.push_back(act_params);
+  }    
 }
 
 bool   fastcat::Manager::IsFaulted() { return faulted_; }

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -343,7 +343,10 @@ std::vector<std::vector<double>> fastcat::Manager::GetActuatorsParam()
     act_param.clear();
     act_param.push_back((*device)->GetActPosMax());    
     act_param.push_back((*device)->GetActPosMin());
-    
+    act_param.push_back((*device)->GetActVelMax());
+    act_param.push_back((*device)->GetActAccMax());
+    act_param.push_back((*device)->GetActCurPeak());
+    act_param.push_back((*device)->GetActCurCont());    
     acts_param.push_back(act_param);
   }
   return acts_param;  

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -306,6 +306,49 @@ fastcat::Manager::GetDeviceStatePointers()
 }
 
 double fastcat::Manager::GetTargetLoopRate() { return target_loop_rate_hz_; }
+
+std::vector<std::string> fastcat::Manager::GetActuatorsName()
+{
+  std::shared_ptr<DeviceState> dev_state;
+  std::string                  dev_name;
+  std::vector<std::string> acts_name;
+  for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
+       ++device){        
+    dev_state = (*device)->GetState();
+    dev_name  = (*device)->GetName();
+
+    if (dev_state->type == ACTUATOR_STATE) {
+      acts_name.push_back(dev_name);      
+    }
+  }
+  return acts_name;  
+}
+
+std::vector<std::vector<double>> fastcat::Manager::GetActuatorsParam()
+{
+  std::shared_ptr<DeviceState> dev_state;
+  std::string                  dev_name;
+  std::vector<std::vector<double>> acts_param;  
+  std::vector<double>          act_param;
+  std::vector<double>          pos_min;
+  for (auto device = jsd_device_list_.begin(); device != jsd_device_list_.end();
+       ++device){        
+    dev_state = (*device)->GetState();
+    dev_name  = (*device)->GetName();
+
+    if (dev_state->type != ACTUATOR_STATE) {
+      continue;
+    }
+    MSG("For act: %s", dev_name.c_str());
+    act_param.clear();
+    act_param.push_back((*device)->GetActPosMax());    
+    act_param.push_back((*device)->GetActPosMin());
+    
+    acts_param.push_back(act_param);
+  }
+  return acts_param;  
+}
+
 bool   fastcat::Manager::IsFaulted() { return faulted_; }
 
 bool fastcat::Manager::RecoverBus(std::string ifname)

--- a/src/manager.h
+++ b/src/manager.h
@@ -91,14 +91,14 @@ class Manager
   double                                          GetTargetLoopRate();
 
   /** @brief Public getter to the YAML actuators names
-   *  @return vectors 
-   */
-  std::vector<std::string>GetActuatorsName();
+   *  @return  
+   */  
+  void GetActuatorsName(std::vector<std::string>>& names);
 
   /** @brief Public getter to the YAML actuators parameters
    *  @return vectors 
    */
-  std::vector<std::vector<double>>GetActuatorsParam();
+  void GetActuatorsParams(std::vector<std::vector<double>>& params);
 
   /** @brief Public getter retrieve fault status
    *  @return true if bus is faulted
@@ -196,7 +196,7 @@ class Manager
   std::vector<DeviceState>                           states_;
   std::map<std::string, ActuatorPosData>             actuator_pos_map_;
   std::unordered_map<std::string, bool>              unique_device_map_;
-  std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;
+  std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;  
 };
 }  // namespace fastcat
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -88,6 +88,16 @@ class Manager
    */
   double                                          GetTargetLoopRate();
 
+  /** @brief Public getter to the YAML actuators names
+   *  @return vectors 
+   */
+  std::vector<std::string>GetActuatorsName();
+
+  /** @brief Public getter to the YAML actuators parameters
+   *  @return vectors 
+   */
+  std::vector<std::vector<double>>GetActuatorsParam();
+
   /** @brief Public getter retrieve fault status
    *  @return true if bus is faulted
    */

--- a/src/manager.h
+++ b/src/manager.h
@@ -93,12 +93,12 @@ class Manager
   /** @brief Public getter to the YAML actuators names
    *  @return  
    */  
-  void GetActuatorsName(std::vector<std::string>>& names);
+  void GetActuatorsName(std::vector<std::string> &names);
 
   /** @brief Public getter to the YAML actuators parameters
    *  @return vectors 
    */
-  void GetActuatorsParams(std::vector<std::vector<double>>& params);
+  void GetActuatorsParams(std::vector<std::shared_ptr<std::vector<double>>> &params);
 
   /** @brief Public getter retrieve fault status
    *  @return true if bus is faulted


### PR DESCRIPTION
- Get function for protected member variables from device_base::actuator
- Added non-pure virtual function to device_base class
- Will be used for fcat to broadcast actuator name/parameters as read only ros parameter.