### PR TITLE
Quiet brake disengage

### DIFF
--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -205,7 +205,10 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    //MSG("Bypassing wait since brakes are disengaged");
+    // Only print this if we are not already in a position profile
+    if(actuator_state_ != ACTUATOR_SMS_PROF_POS){
+      MSG("Bypassing wait since brakes are disengaged");
+    }
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_POS_DISENGAGING);
     last_cmd_ = cmd;
@@ -243,7 +246,10 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    //MSG("Bypassing wait since brakes are disengaged");
+    // Only print this if we are not already in a velocity profile
+    if(actuator_state_ != ACTUATOR_SMS_PROF_VEL){
+      MSG("Bypassing wait since brakes are disengaged");
+    }
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_VEL_DISENGAGING);
     last_cmd_ = cmd;
@@ -281,7 +287,10 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    //MSG("Bypassing wait since brakes are disengaged");
+    // Only print this if we are not already in a torque profile
+    if(actuator_state_ != ACTUATOR_SMS_PROF_TORQUE){
+      MSG("Bypassing wait since brakes are disengaged");
+    }
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_TORQUE_DISENGAGING);
     last_cmd_ = cmd;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -206,7 +206,7 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
     // Only print this if we are not already in a position profile
-    if(actuator_state_ != ACTUATOR_SMS_PROF_POS){
+    if(actuator_sms_ != ACTUATOR_SMS_PROF_POS){
       MSG("Bypassing wait since brakes are disengaged");
     }
   }else{
@@ -247,7 +247,7 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
     // Only print this if we are not already in a velocity profile
-    if(actuator_state_ != ACTUATOR_SMS_PROF_VEL){
+    if(actuator_sms_ != ACTUATOR_SMS_PROF_VEL){
       MSG("Bypassing wait since brakes are disengaged");
     }
   }else{
@@ -288,7 +288,7 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
     // Only print this if we are not already in a torque profile
-    if(actuator_state_ != ACTUATOR_SMS_PROF_TORQUE){
+    if(actuator_sms_ != ACTUATOR_SMS_PROF_TORQUE){
       MSG("Bypassing wait since brakes are disengaged");
     }
   }else{

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -205,7 +205,7 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    MSG("Bypassing wait since brakes are disengaged");
+    //MSG("Bypassing wait since brakes are disengaged");
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_POS_DISENGAGING);
     last_cmd_ = cmd;
@@ -243,7 +243,7 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    MSG("Bypassing wait since brakes are disengaged");
+    //MSG("Bypassing wait since brakes are disengaged");
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_VEL_DISENGAGING);
     last_cmd_ = cmd;
@@ -281,7 +281,7 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    MSG("Bypassing wait since brakes are disengaged");
+    //MSG("Bypassing wait since brakes are disengaged");
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_TORQUE_DISENGAGING);
     last_cmd_ = cmd;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -205,10 +205,7 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    // Only print this if we are not already in a position profile
-    if(actuator_sms_ != ACTUATOR_SMS_PROF_POS){
-      MSG("Bypassing wait since brakes are disengaged");
-    }
+    // Bypassing wait since brakes are disengaged
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_POS_DISENGAGING);
     last_cmd_ = cmd;
@@ -246,10 +243,7 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    // Only print this if we are not already in a velocity profile
-    if(actuator_sms_ != ACTUATOR_SMS_PROF_VEL){
-      MSG("Bypassing wait since brakes are disengaged");
-    }
+    // Bypassing wait since brakes are disengaged
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_VEL_DISENGAGING);
     last_cmd_ = cmd;
@@ -287,10 +281,7 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
 
   // Only transition to disengaging if its needed
   if(state_->actuator_state.servo_enabled){
-    // Only print this if we are not already in a torque profile
-    if(actuator_sms_ != ACTUATOR_SMS_PROF_TORQUE){
-      MSG("Bypassing wait since brakes are disengaged");
-    }
+    // Bypassing wait since brakes are disengaged
   }else{
     TransitionToState(ACTUATOR_SMS_PROF_TORQUE_DISENGAGING);
     last_cmd_ = cmd;


### PR DESCRIPTION
EELS are sending streams of profile inputs to fastcat because they want continuous control with a finite dwell period, but the recent brake disengage fix added a screen print every time a new profile is received while brakes are already disengaged.

This adds a check to see if the actuator state machine is already set to the incoming profile type and skips the print if so (assumes the operator will have already seen the first time this message prints after receiving the first in a stream of profile commands)