### PR TITLE
Expose actuator parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 project(fastcat
     DESCRIPTION "C++ EtherCAT Device Command & Control Library"
-    VERSION 0.4.8
+    VERSION 0.11.5
     LANGUAGES C CXX
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG v2.1.0
+    GIT_TAG v2.1.2
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/src/device_base.cc
+++ b/src/device_base.cc
@@ -23,10 +23,7 @@ void fastcat::DeviceBase::SetLoopPeriod(double loop_period)
   loop_period_ = loop_period;
 }
 
-
-void fastcat::DeviceBase::SetTime(double time){
-  state_->time = time;
-}
+void fastcat::DeviceBase::SetTime(double time) { state_->time = time; }
 
 bool fastcat::DeviceBase::Write(fastcat::DeviceCmd& /* cmd */)
 {
@@ -47,4 +44,3 @@ void fastcat::DeviceBase::Reset()
 }
 
 fastcat::FaultType fastcat::DeviceBase::Process() { return NO_FAULT; }
-

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -39,16 +39,16 @@ class DeviceBase
   std::vector<Signal> signals_;
 
  protected:
-  std::string name_;    ///< unique device name
-  double loop_period_;  ///< only some devices need
+  std::string name_;         ///< unique device name
+  double      loop_period_;  ///< only some devices need
 
   /// device-level fault, manager also has fault status flag
-  bool device_fault_active_ = false;                                      
+  bool device_fault_active_ = false;
 
   std::shared_ptr<DeviceState> state_;  ///< Fastcat state data
 
   /// for intra-device commands
-  std::shared_ptr<std::queue<DeviceCmd>> cmd_queue_;  
+  std::shared_ptr<std::queue<DeviceCmd>> cmd_queue_;
 };
 
 }  // namespace fastcat

--- a/src/fastcat_devices/conditional.cc
+++ b/src/fastcat_devices/conditional.cc
@@ -74,7 +74,6 @@ bool fastcat::Conditional::ConfigFromYaml(YAML::Node node)
 
 bool fastcat::Conditional::Read()
 {
-
   // update input signal
   if (!UpdateSignal(signals_[0])) {
     ERROR("Could not extract signal");

--- a/src/fastcat_devices/fts.cc
+++ b/src/fastcat_devices/fts.cc
@@ -24,7 +24,9 @@ bool fastcat::Fts::ConfigFromYaml(YAML::Node node)
 
   double dummy;
   if (ParseOptVal(node, "max_force", dummy)) {
-    ERROR("fastcat no longer accept L2 norm, configure your yaml values per axis");
+    ERROR(
+        "fastcat no longer accept L2 norm, configure your yaml values per "
+        "axis");
     return false;
   }
 
@@ -129,20 +131,22 @@ bool fastcat::Fts::Read()
 fastcat::FaultType fastcat::Fts::Process()
 {
   if (!device_fault_active_) {
-    if(enable_fts_guard_fault_){
-      if (max_force_[0] < fabs(state_->fts_state.raw_fx) || max_force_[1] < fabs(state_->fts_state.raw_fy) || max_force_[2] < fabs(state_->fts_state.raw_fz) ||
-          max_torque_[0] < fabs(state_->fts_state.raw_tx) || max_torque_[1] < fabs(state_->fts_state.raw_ty) || max_torque_[2] < fabs(state_->fts_state.raw_tz)) {
+    if (enable_fts_guard_fault_) {
+      if (max_force_[0] < fabs(state_->fts_state.raw_fx) ||
+          max_force_[1] < fabs(state_->fts_state.raw_fy) ||
+          max_force_[2] < fabs(state_->fts_state.raw_fz) ||
+          max_torque_[0] < fabs(state_->fts_state.raw_tx) ||
+          max_torque_[1] < fabs(state_->fts_state.raw_ty) ||
+          max_torque_[2] < fabs(state_->fts_state.raw_tz)) {
         ERROR(
             "Force or torque measured by device %s exceeded maximum allowable "
             "magnitude. Force: [x]: %f / %f, [y]: %f / %f, [z]: %f / %f "
             "Torque: [x]: %f / %f, [y]: %f / %f, [z]: %f / %f",
-            name_.c_str(),
-            state_->fts_state.raw_fx, max_force_[0],
-            state_->fts_state.raw_fy, max_force_[1],
-            state_->fts_state.raw_fz, max_force_[2],
-            state_->fts_state.raw_tx, max_torque_[0],
-            state_->fts_state.raw_ty, max_torque_[1],
-            state_->fts_state.raw_tz, max_torque_[2]);
+            name_.c_str(), state_->fts_state.raw_fx, max_force_[0],
+            state_->fts_state.raw_fy, max_force_[1], state_->fts_state.raw_fz,
+            max_force_[2], state_->fts_state.raw_tx, max_torque_[0],
+            state_->fts_state.raw_ty, max_torque_[1], state_->fts_state.raw_tz,
+            max_torque_[2]);
         return ALL_DEVICE_FAULT;
       }
     }
@@ -153,23 +157,20 @@ fastcat::FaultType fastcat::Fts::Process()
 bool fastcat::Fts::Write(DeviceCmd& cmd)
 {
   if (cmd.type == FTS_TARE_CMD) {
-
     // Do not permit taring if there is a fault
-    if(device_fault_active_){
+    if (device_fault_active_) {
       ERROR("Taring FTS is not permited with a active fault, reset first");
       return false;
-    }else{
+    } else {
       for (int ii = 0; ii < FC_FTS_N_DIMS; ii++) {
         sig_offset_[ii] = -wrench_[ii];
       }
       return true;
     }
-  }
-  else if (cmd.type == FTS_ENABLE_GUARD_FAULT_CMD) {
+  } else if (cmd.type == FTS_ENABLE_GUARD_FAULT_CMD) {
     enable_fts_guard_fault_ = cmd.fts_enable_guard_fault_cmd.enable;
     return true;
-  }
-  else{
+  } else {
     WARNING("That command type is not supported!");
     return false;
   }

--- a/src/fastcat_devices/fts.h
+++ b/src/fastcat_devices/fts.h
@@ -46,17 +46,19 @@ class Fts : public DeviceBase
 
  protected:
   std::vector<std::vector<double>>
-         calibration_;  ///< Calibration matrix of doubles for wrench calculation.
+      calibration_;  ///< Calibration matrix of doubles for wrench calculation.
   double wrench_[FC_FTS_N_DIMS] = {
       0};  ///< Array where wrench values are stored.
   double sig_offset_[FC_FTS_N_DIMS] = {
-      0};                 ///< Double array for storing tare offsets.
+      0};  ///< Double array for storing tare offsets.
 
-  bool enable_fts_guard_fault_ = true;
-  double max_force_[3]  = {0, 0, 0}; ///< If x,y,z axis of force components exceeds
-                                     ///< these values, the entire fastcat system will fault.
-  double max_torque_[3] = {0, 0, 0}; ///< If x,y,z axis of torque components exceeds
-                                     ///< these values, the entire fastcat system will fault.
+  bool   enable_fts_guard_fault_ = true;
+  double max_force_[3]           = {
+                0, 0, 0};  ///< If x,y,z axis of force components exceeds
+                 ///< these values, the entire fastcat system will fault.
+  double max_torque_[3] = {
+      0, 0, 0};  ///< If x,y,z axis of torque components exceeds
+                 ///< these values, the entire fastcat system will fault.
 };
 
 }  // namespace fastcat

--- a/src/fastcat_devices/function.cc
+++ b/src/fastcat_devices/function.cc
@@ -15,18 +15,20 @@ fastcat::Function::Function()
   state_->type = FUNCTION_STATE;
 }
 
-fastcat::FunctionType fastcat::FunctionTypeFromString(const std::string& function_type) {
-  if(function_type.compare("POLYNOMIAL") == 0) {
+fastcat::FunctionType fastcat::FunctionTypeFromString(
+    const std::string& function_type)
+{
+  if (function_type.compare("POLYNOMIAL") == 0) {
     return POLYNOMIAL;
-  } else if(function_type.compare("SUMMATION") == 0) {
+  } else if (function_type.compare("SUMMATION") == 0) {
     return SUMMATION;
-  } else if(function_type.compare("MULTIPLICATION") == 0) {
+  } else if (function_type.compare("MULTIPLICATION") == 0) {
     return MULTIPLICATION;
-  } else if(function_type.compare("POWER") == 0) {
+  } else if (function_type.compare("POWER") == 0) {
     return POWER;
-  } else if(function_type.compare("EXPONENTIAL") == 0) {
+  } else if (function_type.compare("EXPONENTIAL") == 0) {
     return EXPONENTIAL;
-  } else if(function_type.compare("SIGMOID") == 0) {
+  } else if (function_type.compare("SIGMOID") == 0) {
     return SIGMOID;
   } else {
     return BAD_FUNCTION_TYPE;
@@ -43,34 +45,35 @@ bool fastcat::Function::ConfigFromYaml(YAML::Node node)
   if (!ParseVal(node, "function_type", function_type_string_)) {
     return false;
   }
-  
+
   function_type_ = fastcat::FunctionTypeFromString(function_type_string_);
   if (!ConfigSignalsFromYaml(node, signals_, false)) {
     return false;
   }
- 
-  switch(function_type_) {
 
-    case POLYNOMIAL: { 
-
+  switch (function_type_) {
+    case POLYNOMIAL: {
       if (!ParseVal(node, "order", polynomial_params_.order)) {
         return false;
       }
-     
+
       YAML::Node coeff_node;
       if (!ParseList(node, "coefficients", coeff_node)) {
         return false;
       }
-     
-      for (auto coeff = coeff_node.begin(); coeff != coeff_node.end(); ++coeff) {
+
+      for (auto coeff = coeff_node.begin(); coeff != coeff_node.end();
+           ++coeff) {
         polynomial_coefficients_.push_back((*coeff).as<double>());
       }
-     
-      if (polynomial_params_.order != static_cast<int>(polynomial_coefficients_.size()) - 1) {
-        ERROR("for a polynomial of %d-order, expecting %d coefficients. %lu found",
-              polynomial_params_.order, polynomial_params_.order + 1, 
-              polynomial_coefficients_.size()
-        );
+
+      if (polynomial_params_.order !=
+          static_cast<int>(polynomial_coefficients_.size()) - 1) {
+        ERROR(
+            "for a polynomial of %d-order, expecting %d coefficients. %lu "
+            "found",
+            polynomial_params_.order, polynomial_params_.order + 1,
+            polynomial_coefficients_.size());
         return false;
       }
       // print the coefficients
@@ -78,30 +81,32 @@ bool fastcat::Function::ConfigFromYaml(YAML::Node node)
       for (int i = 0; i <= polynomial_params_.order; ++i) {
         char term[64];
         if (i == polynomial_params_.order) {
-          snprintf(term, 64, "(%f)*x^%d ", polynomial_coefficients_[i], polynomial_params_.order - i);
+          snprintf(term, 64, "(%f)*x^%d ", polynomial_coefficients_[i],
+                   polynomial_params_.order - i);
         } else {
-          snprintf(term, 64, "(%f)*x^%d + ", polynomial_coefficients_[i], polynomial_params_.order - i);
+          snprintf(term, 64, "(%f)*x^%d + ", polynomial_coefficients_[i],
+                   polynomial_params_.order - i);
         }
         coeff_str.append(term);
       }
       MSG("Function: %s %s", name_.c_str(), coeff_str.c_str());
-     
+
       if (signals_.size() != 1) {
         ERROR("Expecting exactly one signal for Function");
         return false;
-      } 
-    
+      }
+
       break;
     }
 
-    case SUMMATION:    
+    case SUMMATION:
       break;
 
     case MULTIPLICATION: {
       if (signals_.size() < 2) {
         ERROR("Expecting at least two signals for Function");
         return false;
-      } 
+      }
       break;
     }
 
@@ -109,7 +114,7 @@ bool fastcat::Function::ConfigFromYaml(YAML::Node node)
       if (signals_.size() != 1) {
         ERROR("Expecting exactly one signal for Function");
         return false;
-      } 
+      }
       if (!ParseVal(node, "exponent", power_params_.exponent)) {
         return false;
       }
@@ -120,12 +125,11 @@ bool fastcat::Function::ConfigFromYaml(YAML::Node node)
       if (signals_.size() != 1) {
         ERROR("Expecting exactly one signal for Function");
         return false;
-      } 
+      }
       if (!ParseVal(node, "base", exponential_params_.base)) {
         WARNING(
-          "No 'base' specified for Function with exponenent type; "
-          "using default value of 'e'"
-        );
+            "No 'base' specified for Function with exponenent type; "
+            "using default value of 'e'");
         exponential_params_.base = exp(1.0);
       }
       break;
@@ -135,14 +139,13 @@ bool fastcat::Function::ConfigFromYaml(YAML::Node node)
       if (signals_.size() != 1) {
         ERROR("Expecting exactly one signal for Function");
         return false;
-      } 
+      }
       break;
     }
 
     case BAD_FUNCTION_TYPE: {
-
-      ERROR("Could not determine function type: %s", 
-        function_type_string_.c_str());
+      ERROR("Could not determine function type: %s",
+            function_type_string_.c_str());
 
       return false;
     }
@@ -153,45 +156,45 @@ bool fastcat::Function::ConfigFromYaml(YAML::Node node)
 
 bool fastcat::Function::Read()
 {
-  for(auto& signal : signals_) {
+  for (auto& signal : signals_) {
     if (!UpdateSignal(signal)) {
       ERROR("Could not extract signal");
       return false;
     }
   }
 
-  switch(function_type_) {
+  switch (function_type_) {
     case POLYNOMIAL: {
       state_->function_state.output = 0.0;
       for (int i = 0; i <= polynomial_params_.order; ++i) {
         state_->function_state.output +=
-          pow(signals_[0].value, polynomial_params_.order - i) * 
-          polynomial_coefficients_[i];
+            pow(signals_[0].value, polynomial_params_.order - i) *
+            polynomial_coefficients_[i];
       }
       break;
     }
     case SUMMATION: {
       state_->function_state.output = 0.0;
-      for(auto& signal : signals_) {
+      for (auto& signal : signals_) {
         state_->function_state.output += signal.value;
       }
       break;
     }
     case MULTIPLICATION: {
       state_->function_state.output = 1.0;
-      for(auto& signal : signals_) {
+      for (auto& signal : signals_) {
         state_->function_state.output *= signal.value;
       }
       break;
     }
     case POWER: {
-      state_->function_state.output = 
-        pow(signals_[0].value, power_params_.exponent);
+      state_->function_state.output =
+          pow(signals_[0].value, power_params_.exponent);
       break;
     }
     case EXPONENTIAL: {
-      state_->function_state.output = 
-        pow(exponential_params_.base, signals_[0].value);
+      state_->function_state.output =
+          pow(exponential_params_.base, signals_[0].value);
       break;
     }
     case SIGMOID: {
@@ -205,5 +208,4 @@ bool fastcat::Function::Read()
   }
 
   return true;
-
 }

--- a/src/fastcat_devices/function.h
+++ b/src/fastcat_devices/function.h
@@ -10,14 +10,14 @@
 
 namespace fastcat
 {
-enum FunctionType { 
-  POLYNOMIAL, 
-  SUMMATION, 
-  MULTIPLICATION, 
-  POWER, 
+enum FunctionType {
+  POLYNOMIAL,
+  SUMMATION,
+  MULTIPLICATION,
+  POWER,
   EXPONENTIAL,
   SIGMOID,
-  BAD_FUNCTION_TYPE 
+  BAD_FUNCTION_TYPE
 };
 FunctionType FunctionTypeFromString(const std::string&);
 
@@ -39,16 +39,17 @@ class Function : public DeviceBase
   Function();
   bool ConfigFromYaml(YAML::Node node) override;
   bool Read() override;
+
  protected:
-  std::string         function_type_string_;
-  enum FunctionType   function_type_;
+  std::string       function_type_string_;
+  enum FunctionType function_type_;
 
   std::vector<double> polynomial_coefficients_;
   union {
-    PolynomialParams polynomial_params_;
-    PowerParams power_params_;
+    PolynomialParams  polynomial_params_;
+    PowerParams       power_params_;
     ExponentialParams exponential_params_;
-  };  
+  };
 };
 
 }  // namespace fastcat

--- a/src/fastcat_devices/linear_interpolation.cc
+++ b/src/fastcat_devices/linear_interpolation.cc
@@ -2,9 +2,9 @@
 #include "fastcat/fastcat_devices/linear_interpolation.h"
 
 // Include c then c++ libraries
-#include <cmath>
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <cmath>
 
 // Include external then project includes
 #include "fastcat/signal_handling.h"
@@ -24,7 +24,8 @@ bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node)
   }
   state_->name = name_;
 
-  if (!ParseVal(node, "enable_out_of_bounds_fault", enable_out_of_bounds_fault_)){
+  if (!ParseVal(node, "enable_out_of_bounds_fault",
+                enable_out_of_bounds_fault_)) {
     return false;
   }
 
@@ -38,23 +39,25 @@ bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if(range_node.size() < 2){
-    ERROR("Interpolation Table must consist of at least 2 elements. Provided: (%zu)", 
+  if (range_node.size() < 2) {
+    ERROR(
+        "Interpolation Table must consist of at least 2 elements. Provided: "
+        "(%zu)",
         range_node.size());
     return false;
   }
 
-  if(range_node.size() != domain_node.size()){
-    ERROR("Range size (%zu) and Domain size (%zu) do no match", 
-        range_node.size(), domain_node.size());
+  if (range_node.size() != domain_node.size()) {
+    ERROR("Range size (%zu) and Domain size (%zu) do no match",
+          range_node.size(), domain_node.size());
     return false;
   }
   domain_range_.resize(range_node.size());
 
   // group together before sorting
   auto domain_iter = domain_node.begin();
-  auto range_iter = range_node.begin();
-  for(size_t i = 0; i < range_node.size(); i++){
+  auto range_iter  = range_node.begin();
+  for (size_t i = 0; i < range_node.size(); i++) {
     domain_range_[i].first  = domain_iter->as<double>();
     domain_range_[i].second = range_iter->as<double>();
     domain_iter++;
@@ -62,32 +65,28 @@ bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node)
   }
 
   // Finally sort them by increasing domain
-  std::sort(
-    domain_range_.begin(), 
-    domain_range_.end(), 
-    [](auto &lhs, auto &rhs) { 
-      return lhs.first < rhs.first;
-      });
+  std::sort(domain_range_.begin(), domain_range_.end(),
+            [](auto& lhs, auto& rhs) { return lhs.first < rhs.first; });
 
   // And precompute the slope
-  slope_.resize(range_node.size()-1);
+  slope_.resize(range_node.size() - 1);
   MSG_DEBUG("Interpolation Table (%s)", name_.c_str());
   MSG_DEBUG("row: domain, range, slope ");
   size_t i;
-  for(i = 0; i < domain_range_.size()-1; i++){
-    double dy = domain_range_[i+1].second - domain_range_[i].second;
-    double dx = domain_range_[i+1].first  - domain_range_[i].first;
-    if(fabs(dx) < 1e-16){
+  for (i = 0; i < domain_range_.size() - 1; i++) {
+    double dy = domain_range_[i + 1].second - domain_range_[i].second;
+    double dx = domain_range_[i + 1].first - domain_range_[i].first;
+    if (fabs(dx) < 1e-16) {
       ERROR("Interpolation domain entries are too close (or repeated)");
       return false;
     }
-    slope_[i] = dy/dx;
+    slope_[i] = dy / dx;
 
-    MSG_DEBUG("%zu: %lf, %lf, %lf", 
-        i, domain_range_[i].first, domain_range_[i].second, slope_[i]);
+    MSG_DEBUG("%zu: %lf, %lf, %lf", i, domain_range_[i].first,
+              domain_range_[i].second, slope_[i]);
   }
-  MSG_DEBUG("%zu: %lf, %lf, N/A", 
-      i, domain_range_[i].first, domain_range_[i].second);
+  MSG_DEBUG("%zu: %lf, %lf, N/A", i, domain_range_[i].first,
+            domain_range_[i].second);
 
   if (!ConfigSignalsFromYaml(node, signals_, false)) {
     return false;
@@ -100,9 +99,8 @@ bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node)
   return true;
 }
 
-
-bool fastcat::LinearInterpolation::Read() {
-
+bool fastcat::LinearInterpolation::Read()
+{
   // update input signal
   if (!UpdateSignal(signals_[0])) {
     ERROR("Could not extract signal");
@@ -119,23 +117,22 @@ bool fastcat::LinearInterpolation::Read() {
   state_->linear_interpolation_state.is_saturated = false;
 
   // Check if the input signal is off the interp table
-  if(signal_value < domain_min){
-    state_->linear_interpolation_state.output = range_min;
+  if (signal_value < domain_min) {
+    state_->linear_interpolation_state.output       = range_min;
     state_->linear_interpolation_state.is_saturated = true;
 
-  }else if(signal_value > domain_max){
-    state_->linear_interpolation_state.output = range_max;
+  } else if (signal_value > domain_max) {
+    state_->linear_interpolation_state.output       = range_max;
     state_->linear_interpolation_state.is_saturated = true;
   }
 
-  if(state_->linear_interpolation_state.is_saturated){
-
+  if (state_->linear_interpolation_state.is_saturated) {
     // only return false to indicate a NEW fault condition
-    if(enable_out_of_bounds_fault_ and (not device_fault_active_)) {
-      ERROR("Linear Interpolation (%s) out of interpolation domain (%g to %g) signal was (%g)", 
-        name_.c_str(), 
-        domain_min, domain_max,
-        signal_value);
+    if (enable_out_of_bounds_fault_ and (not device_fault_active_)) {
+      ERROR(
+          "Linear Interpolation (%s) out of interpolation domain (%g to %g) "
+          "signal was (%g)",
+          name_.c_str(), domain_min, domain_max, signal_value);
       return false;
     }
 
@@ -143,30 +140,26 @@ bool fastcat::LinearInterpolation::Read() {
     return true;
   }
 
-  
-
   //// calc linear interpolation: output[i] = y[i] + m[i](input[i] - x[i])
   // Find where in the domain we fall and compute linear interpolation
   // Performance improvement: could precompute slope array
   // Performance improvement: divide-and-conquer to find the pivot
   //   rather than linear scan for log(n)-time, rather than n-time here
   size_t i;
-  for(i = 0; i < domain_range_.size()-1; i++){
+  for (i = 0; i < domain_range_.size() - 1; i++) {
     double x1 = domain_range_[i].first;
     double y1 = domain_range_[i].second;
-    double x2 = domain_range_[i+1].first;
-    double y2 = domain_range_[i+1].second;
+    double x2 = domain_range_[i + 1].first;
+    double y2 = domain_range_[i + 1].second;
 
-    if( (signal_value <= x2) && (signal_value > x1)) {
-
-      state_->linear_interpolation_state.output = 
-        y1 + (y2-y1)/(x2-x1)*(signal_value - x1);
+    if ((signal_value <= x2) && (signal_value > x1)) {
+      state_->linear_interpolation_state.output =
+          y1 + (y2 - y1) / (x2 - x1) * (signal_value - x1);
       return true;
     }
   }
 
   ERROR("Linear Interpolation (%s) internal error for signal value (%g)",
-      name_.c_str(), 
-      signal_value);
+        name_.c_str(), signal_value);
   return false;
 }

--- a/src/fastcat_devices/linear_interpolation.h
+++ b/src/fastcat_devices/linear_interpolation.h
@@ -11,7 +11,7 @@
 namespace fastcat
 {
 
-class LinearInterpolation: public DeviceBase
+class LinearInterpolation : public DeviceBase
 {
  public:
   LinearInterpolation();
@@ -21,9 +21,9 @@ class LinearInterpolation: public DeviceBase
  protected:
   // Config paramters
   std::vector<std::pair<double, double>> domain_range_;
-  bool enable_out_of_bounds_fault_ = false;
+  bool                                   enable_out_of_bounds_fault_ = false;
 
-  std::vector<double> slope_; // computed during initialization
+  std::vector<double> slope_;  // computed during initialization
 };
 
 }  // namespace fastcat

--- a/src/fastcat_devices/pid.cc
+++ b/src/fastcat_devices/pid.cc
@@ -114,8 +114,9 @@ bool fastcat::Pid::Write(DeviceCmd& cmd)
     return false;
   }
 
-  if(device_fault_active_){
-    ERROR("Unable to Activate PID (%s) with an active fault, reset first", name_.c_str());
+  if (device_fault_active_) {
+    ERROR("Unable to Activate PID (%s) with an active fault, reset first",
+          name_.c_str());
     return false;
   }
 

--- a/src/fastcat_devices/pid.h
+++ b/src/fastcat_devices/pid.h
@@ -26,7 +26,7 @@ class Pid : public DeviceBase
   double windup_limit_;
 
   PidActivateCmd pid_activate_cmd_ = {0};
-  double         activation_time_ = 0;
+  double         activation_time_  = 0;
 
   double  error_               = 0;
   double  prev_error_          = 0;

--- a/src/fastcat_devices/saturation.cc
+++ b/src/fastcat_devices/saturation.cc
@@ -43,7 +43,6 @@ bool fastcat::Saturation::ConfigFromYaml(YAML::Node node)
 
 bool fastcat::Saturation::Read()
 {
-
   // update input signal
   if (!UpdateSignal(signals_[0])) {
     ERROR("Could not extract signal");

--- a/src/fastcat_devices/signal_generator.cc
+++ b/src/fastcat_devices/signal_generator.cc
@@ -8,22 +8,22 @@
 #include "fastcat/yaml_parser.h"
 #include "jsd/jsd_print.h"
 
-
 fastcat::SignalGeneratorType fastcat::SignalGeneratorTypeFromString(
-    const std::string& signal_generator_type) {
-  if(signal_generator_type.compare("SINE_WAVE") == 0) {
+    const std::string& signal_generator_type)
+{
+  if (signal_generator_type.compare("SINE_WAVE") == 0) {
     return SINE_WAVE;
-  } else if(signal_generator_type.compare("SAW_TOOTH") == 0) {
-    return SAW_TOOTH;;
-  } else if(signal_generator_type.compare("GAUSSIAN_RANDOM") == 0) {
+  } else if (signal_generator_type.compare("SAW_TOOTH") == 0) {
+    return SAW_TOOTH;
+    ;
+  } else if (signal_generator_type.compare("GAUSSIAN_RANDOM") == 0) {
     return GAUSSIAN_RANDOM;
-  } else if(signal_generator_type.compare("UNIFORM_RANDOM") == 0) {
+  } else if (signal_generator_type.compare("UNIFORM_RANDOM") == 0) {
     return UNIFORM_RANDOM;
   } else {
     return BAD_SIGNAL_GENERATOR_TYPE;
   }
 }
-
 
 fastcat::SignalGenerator::SignalGenerator()
 {
@@ -43,11 +43,11 @@ bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node)
   if (!ParseVal(node, "signal_generator_type", signal_generator_type_string_)) {
     return false;
   }
-  
-  signal_generator_type_ = SignalGeneratorTypeFromString(signal_generator_type_string_);
-  switch(signal_generator_type_) {
-    case SINE_WAVE: {
 
+  signal_generator_type_ =
+      SignalGeneratorTypeFromString(signal_generator_type_string_);
+  switch (signal_generator_type_) {
+    case SINE_WAVE: {
       if (!ParseVal(node, "angular_frequency", sine_wave_.angular_frequency)) {
         return false;
       }
@@ -75,7 +75,7 @@ bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node)
       if (!ParseVal(node, "min", saw_tooth_.min)) {
         return false;
       }
-      saw_tooth_.range = saw_tooth_.max - saw_tooth_.min;
+      saw_tooth_.range  = saw_tooth_.max - saw_tooth_.min;
       saw_tooth_.modulo = 0;
       if (saw_tooth_.max < saw_tooth_.min) {
         ERROR("Sawtooth Max (%lf) is not > Min (%lf)", saw_tooth_.max,
@@ -85,62 +85,59 @@ bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node)
       break;
     }
     case GAUSSIAN_RANDOM: {
-      if(!ParseVal(node, "seed", gaussian_random_.seed)) {
-        WARNING("Key 'seed' not supplied, using default random number generator"); 
+      if (!ParseVal(node, "seed", gaussian_random_.seed)) {
+        WARNING(
+            "Key 'seed' not supplied, using default random number generator");
       } else {
         gaussian_random_.seed = 1;
       }
-      if(!ParseVal(node, "mean", gaussian_random_.mean)) {
+      if (!ParseVal(node, "mean", gaussian_random_.mean)) {
         return false;
       }
-      if(!ParseVal(node, "sigma", gaussian_random_.sigma)) {
+      if (!ParseVal(node, "sigma", gaussian_random_.sigma)) {
         return false;
       }
       generator_.seed(gaussian_random_.seed);
-      gaussian_random_.distribution = 
-        std::normal_distribution<double>(
-          gaussian_random_.mean, gaussian_random_.sigma
-        );
+      gaussian_random_.distribution = std::normal_distribution<double>(
+          gaussian_random_.mean, gaussian_random_.sigma);
       break;
     }
     case UNIFORM_RANDOM: {
-      if(!ParseVal(node, "seed", uniform_random_.seed)) {
-        WARNING("Key 'seed' not supplied, using default random number generator"); 
+      if (!ParseVal(node, "seed", uniform_random_.seed)) {
+        WARNING(
+            "Key 'seed' not supplied, using default random number generator");
       } else {
         uniform_random_.seed = 1;
       }
-      if(!ParseVal(node, "min", uniform_random_.min)) {
+      if (!ParseVal(node, "min", uniform_random_.min)) {
         return false;
       }
-      if(!ParseVal(node, "max", uniform_random_.max)) {
+      if (!ParseVal(node, "max", uniform_random_.max)) {
         return false;
       }
       generator_.seed(uniform_random_.seed);
-      uniform_random_.distribution = 
-        std::uniform_real_distribution<double>(
-          uniform_random_.min, uniform_random_.max
-        );
+      uniform_random_.distribution = std::uniform_real_distribution<double>(
+          uniform_random_.min, uniform_random_.max);
       break;
     }
     default: {
       ERROR("signal_generator_type %s is invalid",
-        signal_generator_type_string_.c_str());
+            signal_generator_type_string_.c_str());
       return false;
     }
-
   }
   return true;
 }
 
 bool fastcat::SignalGenerator::Read()
 {
-  switch(signal_generator_type_) {
-
+  switch (signal_generator_type_) {
     case SINE_WAVE: {
       state_->signal_generator_state.output =
-        sine_wave_.offset +
-        sine_wave_.amplitude *
-            sin(sine_wave_.angular_frequency * state_->time + sine_wave_.phase);
+          sine_wave_.offset +
+          sine_wave_.amplitude *
+              sin(sine_wave_.angular_frequency * state_->time +
+                  sine_wave_.phase);
       break;
     }
 
@@ -176,14 +173,14 @@ bool fastcat::SignalGenerator::Read()
     }
 
     case GAUSSIAN_RANDOM: {
-      state_->signal_generator_state.output = 
-        gaussian_random_.distribution(generator_);
+      state_->signal_generator_state.output =
+          gaussian_random_.distribution(generator_);
       break;
     }
 
     case UNIFORM_RANDOM: {
-       state_->signal_generator_state.output = 
-        uniform_random_.distribution(generator_);
+      state_->signal_generator_state.output =
+          uniform_random_.distribution(generator_);
       break;
     }
 
@@ -191,7 +188,6 @@ bool fastcat::SignalGenerator::Read()
       ERROR("Unhandled signal_generator_type");
       return false;
     }
-
   }
 
   return true;

--- a/src/fastcat_devices/signal_generator.h
+++ b/src/fastcat_devices/signal_generator.h
@@ -12,12 +12,12 @@
 
 namespace fastcat
 {
-enum SignalGeneratorType { 
-  SINE_WAVE, 
-  SAW_TOOTH, 
-  GAUSSIAN_RANDOM, 
-  UNIFORM_RANDOM, 
-  BAD_SIGNAL_GENERATOR_TYPE 
+enum SignalGeneratorType {
+  SINE_WAVE,
+  SAW_TOOTH,
+  GAUSSIAN_RANDOM,
+  UNIFORM_RANDOM,
+  BAD_SIGNAL_GENERATOR_TYPE
 };
 
 SignalGeneratorType SignalGeneratorTypeFromString(const std::string&);
@@ -38,16 +38,16 @@ typedef struct {
 } SawToothParams;
 
 typedef struct {
-  uint32_t seed = 1;
-  double mean;
-  double sigma;
+  uint32_t                         seed = 1;
+  double                           mean;
+  double                           sigma;
   std::normal_distribution<double> distribution;
 } GaussianRandomParams;
 
 typedef struct {
-  uint32_t seed = 1;
-  double min;
-  double max;  
+  uint32_t                               seed = 1;
+  double                                 min;
+  double                                 max;
   std::uniform_real_distribution<double> distribution;
 } UniformRandomParams;
 
@@ -59,16 +59,16 @@ class SignalGenerator : public DeviceBase
   bool Read() override;
 
  protected:
-  std::string              signal_generator_type_string_;
-  enum SignalGeneratorType signal_generator_type_;
-  double                   start_time_ = 0;
+  std::string                signal_generator_type_string_;
+  enum SignalGeneratorType   signal_generator_type_;
+  double                     start_time_ = 0;
   std::default_random_engine generator_;
 
   union {
-    SineWaveParams sine_wave_;
-    SawToothParams saw_tooth_;
+    SineWaveParams       sine_wave_;
+    SawToothParams       saw_tooth_;
     GaussianRandomParams gaussian_random_;
-    UniformRandomParams uniform_random_;
+    UniformRandomParams  uniform_random_;
   };
 };
 

--- a/src/fastcat_devices/virtual_fts.cc
+++ b/src/fastcat_devices/virtual_fts.cc
@@ -65,7 +65,9 @@ bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node)
 
   double dummy;
   if (ParseOptVal(node, "max_force", dummy)) {
-    ERROR("fastcat no longer accept L2 norm, configure your yaml values per axis");
+    ERROR(
+        "fastcat no longer accept L2 norm, configure your yaml values per "
+        "axis");
     return false;
   }
 

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -30,125 +30,125 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if (!ParseVal(node, "actuator_type", actuator_type_str_)) {
+  if (!ParseVal(node, "actuator_type", params_.actuator_type_str)) {
     return false;
   }
 
-  if (0 == actuator_type_str_.compare("revolute")) {
+  if (0 == params_.actuator_type_str.compare("revolute")) {
     actuator_type_ = ACTUATOR_TYPE_REVOLUTE;
 
-  } else if (0 == actuator_type_str_.compare("prismatic")) {
+  } else if (0 == params_.actuator_type_str.compare("prismatic")) {
     actuator_type_ = ACTUATOR_TYPE_PRISMATIC;
 
   } else {
     ERROR("Failed to parse actuator_type string: %s must be %s or %s",
-          actuator_type_str_.c_str(), "revolute", "prismatic");
+          params_.actuator_type_str.c_str(), "revolute", "prismatic");
     return false;
   }
 
-  if (!ParseValCheckRange(node, "gear_ratio", gear_ratio_, 0, 1.0e12)) {
+  if (!ParseValCheckRange(node, "gear_ratio", params_.gear_ratio, 0, 1.0e12)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "counts_per_rev", counts_per_rev_, 0, 1.0e12)) {
+  if (!ParseValCheckRange(node, "counts_per_rev", params_.counts_per_rev, 0, 1.0e12)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "max_speed_eu_per_sec", max_speed_eu_per_sec_,
+  if (!ParseValCheckRange(node, "max_speed_eu_per_sec", params_.max_speed_eu_per_sec,
                           0, (double)INT32_MAX + 1.0)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "max_accel_eu_per_sec2", max_accel_eu_per_sec2_,
+  if (!ParseValCheckRange(node, "max_accel_eu_per_sec2", params_.max_accel_eu_per_sec2,
                           0, (double)INT32_MAX + 1.0)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "over_speed_multiplier", over_speed_multiplier_,
+  if (!ParseValCheckRange(node, "over_speed_multiplier", params_.over_speed_multiplier,
                           0.0, 1000.0)) {
     return false;
   }
 
   if (!ParseValCheckRange(node, "vel_tracking_error_eu_per_sec",
-                          vel_tracking_error_eu_per_sec_, 0,
+                          params_.vel_tracking_error_eu_per_sec, 0,
                           (double)INT32_MAX + 1.0)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "pos_tracking_error_eu", pos_tracking_error_eu_,
+  if (!ParseValCheckRange(node, "pos_tracking_error_eu", params_.pos_tracking_error_eu,
                           0, (double)INT32_MAX + 1.0)) {
     return false;
   }
 
   if (!ParseValCheckRange(node, "peak_current_limit_amps",
-                          peak_current_limit_amps_, 0, 100)) {
+                          params_.peak_current_limit_amps, 0, 100)) {
     return false;
   }
-  if (!ParseValCheckRange(node, "peak_current_time_sec", peak_current_time_sec_,
+  if (!ParseValCheckRange(node, "peak_current_time_sec", params_.peak_current_time_sec,
                           0, 60.0)) {
     return false;
   }
   if (!ParseValCheckRange(node, "continuous_current_limit_amps",
-                          continuous_current_limit_amps_, 0, 100)) {
+                          params_.continuous_current_limit_amps, 0, 100)) {
     return false;
   }
   if (!ParseValCheckRange(node, "torque_slope_amps_per_sec",
-                          torque_slope_amps_per_sec_, 0, 1000.0)) {
+                          params_.torque_slope_amps_per_sec, 0, 1000.0)) {
     return false;
   }
 
-  if (!ParseVal(node, "low_pos_cal_limit_eu", low_pos_cal_limit_eu_)) {
+  if (!ParseVal(node, "low_pos_cal_limit_eu", params_.low_pos_cal_limit_eu)) {
     return false;
   }
-  if (!ParseVal(node, "low_pos_cmd_limit_eu", low_pos_cmd_limit_eu_)) {
-    return false;
-  }
-
-  if (!ParseVal(node, "high_pos_cal_limit_eu", high_pos_cal_limit_eu_)) {
-    return false;
-  }
-  if (!ParseVal(node, "high_pos_cmd_limit_eu", high_pos_cmd_limit_eu_)) {
+  if (!ParseVal(node, "low_pos_cmd_limit_eu", params_.low_pos_cmd_limit_eu)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "holding_duration_sec", holding_duration_sec_,
+  if (!ParseVal(node, "high_pos_cal_limit_eu", params_.high_pos_cal_limit_eu)) {
+    return false;
+  }
+  if (!ParseVal(node, "high_pos_cmd_limit_eu", params_.high_pos_cmd_limit_eu)) {
+    return false;
+  }
+
+  if (!ParseValCheckRange(node, "holding_duration_sec", params_.holding_duration_sec,
                           0, 1000.0)) {
     return false;
   }
 
-  if (!ParseVal(node, "egd_brake_engage_msec", egd_brake_engage_msec_)) {
+  if (!ParseVal(node, "egd_brake_engage_msec", params_.egd_brake_engage_msec)) {
     return false;
   }
-  if (!ParseVal(node, "egd_brake_disengage_msec", egd_brake_disengage_msec_)) {
+  if (!ParseVal(node, "egd_brake_disengage_msec", params_.egd_brake_disengage_msec)) {
     return false;
   }
-  if (!ParseVal(node, "egd_crc", egd_crc_)) {
+  if (!ParseVal(node, "egd_crc", params_.egd_crc)) {
     return false;
   }
   if (!ParseVal(node, "egd_drive_max_current_limit",
-                egd_drive_max_cur_limit_amps_)) {
+                params_.egd_drive_max_cur_limit_amps)) {
     return false;
   }
-  if (!ParseValCheckRange(node, "smooth_factor", smooth_factor_, -1, 64)) {
+  if (!ParseValCheckRange(node, "smooth_factor", params_.smooth_factor, -1, 64)) {
     return false;
   }
   
-  if (ParseOptValCheckRange(node, "torque_constant", torque_constant_, 0.0, 999999.0) &&
-      ParseOptValCheckRange(node, "winding_resistance", winding_resistance_, 0.0, 999999.0) ) {
+  if (ParseOptValCheckRange(node, "torque_constant", params_.torque_constant, 0.0, 999999.0) &&
+      ParseOptValCheckRange(node, "winding_resistance", params_.winding_resistance, 0.0, 999999.0) ) {
     
     // Only compute power if we received both torque_constant and winding_resistance parameters
     compute_power_ = true;
     
     // Read in brake power (if provided) to add to actuator power
-    if (!ParseOptValCheckRange(node, "brake_power", brake_power_, 0.0, 9999.0)) {
+    if (!ParseOptValCheckRange(node, "brake_power", params_.brake_power, 0.0, 9999.0)) {
       // If not found then set to zero
-      brake_power_ = 0.0;
+      params_.brake_power = 0.0;
     }
     
     // Read in any gear ratio between the motor and encoder for power calculation
-    if (!ParseOptValCheckRange(node, "motor_encoder_gear_ratio", motor_encoder_gear_ratio_, 0.0, 9999.0)) {
+    if (!ParseOptValCheckRange(node, "motor_encoder_gear_ratio", params_.motor_encoder_gear_ratio, 0.0, 9999.0)) {
       // If not found then set to 1.0
-      motor_encoder_gear_ratio_ = 1.0;
+      params_.motor_encoder_gear_ratio = 1.0;
     }
   }
 
@@ -164,9 +164,9 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
         JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
   }
 
-  if (!ParseOptVal(node, "absolute_encoder", actuator_absolute_encoder_)) {
+  if (!ParseOptVal(node, "absolute_encoder", params_.actuator_absolute_encoder)) {
     // If we do not find this parameter then set it to false
-    actuator_absolute_encoder_ = false;
+    params_.actuator_absolute_encoder = false;
   }
 
   // Whether position should be actively controlled after a profile position
@@ -177,10 +177,10 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
 
   // overall_reduction must be set before using EuToCnts/CntsToEu
   if (actuator_type_ == ACTUATOR_TYPE_REVOLUTE) {
-    overall_reduction_ = counts_per_rev_ * gear_ratio_ / (2.0 * M_PI);
+    overall_reduction_ = params_.counts_per_rev * params_.gear_ratio / (2.0 * M_PI);
 
   } else if (actuator_type_ == ACTUATOR_TYPE_PRISMATIC) {
-    overall_reduction_ = counts_per_rev_ * gear_ratio_;
+    overall_reduction_ = params_.counts_per_rev * params_.gear_ratio;
 
   } else {
     ERROR("Bad actuator_type: %d", actuator_type_);
@@ -195,31 +195,31 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   jsd_slave_config_.egd.drive_cmd_mode    = JSD_EGD_DRIVE_CMD_MODE_CS;
-  jsd_slave_config_.egd.max_motor_speed   = EuToCnts(max_speed_eu_per_sec_);
+  jsd_slave_config_.egd.max_motor_speed   = EuToCnts(params_.max_speed_eu_per_sec);
   jsd_slave_config_.egd.loop_period_ms    = round(loop_period_ * 1000.0); //elmo's interpolation time period should be slower than actual command loop
-  jsd_slave_config_.egd.torque_slope      = torque_slope_amps_per_sec_;
-  jsd_slave_config_.egd.max_profile_accel = EuToCnts(max_accel_eu_per_sec2_);
-  jsd_slave_config_.egd.max_profile_decel = EuToCnts(max_accel_eu_per_sec2_);
+  jsd_slave_config_.egd.torque_slope      = params_.torque_slope_amps_per_sec;
+  jsd_slave_config_.egd.max_profile_accel = EuToCnts(params_.max_accel_eu_per_sec2);
+  jsd_slave_config_.egd.max_profile_decel = EuToCnts(params_.max_accel_eu_per_sec2);
   jsd_slave_config_.egd.velocity_tracking_error =
-      EuToCnts(vel_tracking_error_eu_per_sec_);
+      EuToCnts(params_.vel_tracking_error_eu_per_sec);
   jsd_slave_config_.egd.position_tracking_error =
-      EuToCnts(pos_tracking_error_eu_);
-  jsd_slave_config_.egd.peak_current_limit = peak_current_limit_amps_;
-  jsd_slave_config_.egd.peak_current_time  = peak_current_time_sec_;
+      EuToCnts(params_.pos_tracking_error_eu);
+  jsd_slave_config_.egd.peak_current_limit = params_.peak_current_limit_amps;
+  jsd_slave_config_.egd.peak_current_time  = params_.peak_current_time_sec;
   jsd_slave_config_.egd.continuous_current_limit =
-      continuous_current_limit_amps_;
+      params_.continuous_current_limit_amps;
   jsd_slave_config_.egd.motor_stuck_current_level_pct  = 0;  // disable
   jsd_slave_config_.egd.motor_stuck_velocity_threshold = 0;  // disable
   jsd_slave_config_.egd.motor_stuck_timeout            = 0;  // disable
   jsd_slave_config_.egd.over_speed_threshold =
-      over_speed_multiplier_ * EuToCnts(max_speed_eu_per_sec_);
+      params_.over_speed_multiplier * EuToCnts(params_.max_speed_eu_per_sec);
   jsd_slave_config_.egd.low_position_limit      = 0;  // disable
   jsd_slave_config_.egd.high_position_limit     = 0;  // disable
-  jsd_slave_config_.egd.brake_engage_msec       = egd_brake_engage_msec_;
-  jsd_slave_config_.egd.brake_disengage_msec    = egd_brake_disengage_msec_;
-  jsd_slave_config_.egd.crc                     = egd_crc_;
-  jsd_slave_config_.egd.drive_max_current_limit = egd_drive_max_cur_limit_amps_;
-  jsd_slave_config_.egd.smooth_factor           = smooth_factor_;
+  jsd_slave_config_.egd.brake_engage_msec       = params_.egd_brake_engage_msec;
+  jsd_slave_config_.egd.brake_disengage_msec    = params_.egd_brake_disengage_msec;
+  jsd_slave_config_.egd.crc                     = params_.egd_crc;
+  jsd_slave_config_.egd.drive_max_current_limit = params_.egd_drive_max_cur_limit_amps;
+  jsd_slave_config_.egd.smooth_factor           = params_.smooth_factor;
 
   EgdSetConfig();
 
@@ -275,19 +275,20 @@ bool fastcat::Actuator::Read()
   if (compute_power_) {
     double motor_velocity =
       fabs(state_->actuator_state.actual_velocity) *
-      gear_ratio_ *
-      motor_encoder_gear_ratio_;
+      params_.gear_ratio *
+      params_.motor_encoder_gear_ratio;
     
     double current = fabs(jsd_egd_state_.actual_current);
 
     // P = R I^2 + K_T * I * \omega
     state_->actuator_state.power = current *
-      (winding_resistance_ * current +
-       torque_constant_ * motor_velocity);
+      (params_.winding_resistance * current +
+       params_.torque_constant * motor_velocity);
 
     // Should check, but assuming motor_on > 0 means brakes powered/disengaged
-    if (state_->actuator_state.motor_on)
-      state_->actuator_state.power += brake_power_;
+    if (state_->actuator_state.motor_on) {
+      state_->actuator_state.power += params_.brake_power;
+    }
   }
   // else
   // state_->actuator_state.power = 0;
@@ -321,10 +322,10 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
 
     case ACTUATOR_SET_MAX_CURRENT_CMD:
       // This application may choose to set this during motions
-      // in order to boost current during accelration/decel
+      // in order to boost current during acceleration/deceleration
       // phases so don't check the state machine
-      peak_current_limit_amps_ = cmd.actuator_set_max_current_cmd.current;
-      EgdSetPeakCurrent(peak_current_limit_amps_);
+      params_.peak_current_limit_amps = cmd.actuator_set_max_current_cmd.current;
+      EgdSetPeakCurrent(params_.peak_current_limit_amps);
       return true;
       break;
 
@@ -566,7 +567,7 @@ bool fastcat::Actuator::SetOutputPosition(double position)
 }
 
 bool fastcat::Actuator::HasAbsoluteEncoder(){
-  return actuator_absolute_encoder_;
+  return params_.actuator_absolute_encoder;
 }
 
 double fastcat::Actuator::CntsToEu(int32_t cnts)
@@ -589,15 +590,15 @@ int32_t fastcat::Actuator::PosEuToCnts(double eu)
 
 bool fastcat::Actuator::PosExceedsCmdLimits(double pos_eu)
 {
-  if (pos_eu > high_pos_cmd_limit_eu_) {
+  if (pos_eu > params_.high_pos_cmd_limit_eu) {
     ERROR("Commanded Position (%lf) exceeds high cmd limit (%lf)", pos_eu,
-          high_pos_cmd_limit_eu_);
+          params_.high_pos_cmd_limit_eu);
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CMD_LIMIT_EXCEEDED;
     return true;
   }
-  if (pos_eu < low_pos_cmd_limit_eu_) {
+  if (pos_eu < params_.low_pos_cmd_limit_eu) {
     ERROR("Commanded Position (%lf) exceeds low cmd limit: (%lf)", pos_eu,
-          low_pos_cmd_limit_eu_);
+          params_.low_pos_cmd_limit_eu);
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CMD_LIMIT_EXCEEDED;
     return true;
   }
@@ -606,9 +607,9 @@ bool fastcat::Actuator::PosExceedsCmdLimits(double pos_eu)
 
 bool fastcat::Actuator::VelExceedsCmdLimits(double vel_eu)
 {
-  if (fabs(vel_eu) > max_speed_eu_per_sec_) {
+  if (fabs(vel_eu) > params_.max_speed_eu_per_sec) {
     ERROR("Commanded Velocity (%lf) exceeds max speed limit (%lf)", vel_eu,
-          max_speed_eu_per_sec_);
+          params_.max_speed_eu_per_sec);
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CMD_LIMIT_EXCEEDED;
     return true;
   }
@@ -617,9 +618,9 @@ bool fastcat::Actuator::VelExceedsCmdLimits(double vel_eu)
 
 bool fastcat::Actuator::AccExceedsCmdLimits(double acc_eu)
 {
-  if (fabs(acc_eu) > max_accel_eu_per_sec2_) {
+  if (fabs(acc_eu) > params_.max_accel_eu_per_sec2) {
     ERROR("Commanded Acceleration (%lf) exceeds max limit (%lf)", acc_eu,
-          max_accel_eu_per_sec2_);
+          params_.max_accel_eu_per_sec2);
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CMD_LIMIT_EXCEEDED;
     return true;
   }
@@ -628,16 +629,16 @@ bool fastcat::Actuator::AccExceedsCmdLimits(double acc_eu)
 
 bool fastcat::Actuator::CurrentExceedsCmdLimits(double current)
 {
-  if (fabs(current) > continuous_current_limit_amps_) {
+  if (fabs(current) > params_.continuous_current_limit_amps) {
     WARNING(
         "Commanded current (%lf) exceeds max continuous current limit (%lf)",
-        current, continuous_current_limit_amps_);
+        current, params_.continuous_current_limit_amps);
     // Not issuing fault for now
   }
 
-  if (fabs(current) > peak_current_limit_amps_) {
+  if (fabs(current) > params_.peak_current_limit_amps) {
     ERROR("Commanded current (%lf) exceeds max peak current limit (%lf)",
-          current, peak_current_limit_amps_);
+          current, params_.peak_current_limit_amps);
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CMD_LIMIT_EXCEEDED;
     return true;
   }

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -50,22 +50,25 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if (!ParseValCheckRange(node, "counts_per_rev", params_.counts_per_rev, 0, 1.0e12)) {
+  if (!ParseValCheckRange(node, "counts_per_rev", params_.counts_per_rev, 0,
+                          1.0e12)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "max_speed_eu_per_sec", params_.max_speed_eu_per_sec,
-                          0, (double)INT32_MAX + 1.0)) {
+  if (!ParseValCheckRange(node, "max_speed_eu_per_sec",
+                          params_.max_speed_eu_per_sec, 0,
+                          (double)INT32_MAX + 1.0)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "max_accel_eu_per_sec2", params_.max_accel_eu_per_sec2,
-                          0, (double)INT32_MAX + 1.0)) {
+  if (!ParseValCheckRange(node, "max_accel_eu_per_sec2",
+                          params_.max_accel_eu_per_sec2, 0,
+                          (double)INT32_MAX + 1.0)) {
     return false;
   }
 
-  if (!ParseValCheckRange(node, "over_speed_multiplier", params_.over_speed_multiplier,
-                          0.0, 1000.0)) {
+  if (!ParseValCheckRange(node, "over_speed_multiplier",
+                          params_.over_speed_multiplier, 0.0, 1000.0)) {
     return false;
   }
 
@@ -75,8 +78,9 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if (!ParseValCheckRange(node, "pos_tracking_error_eu", params_.pos_tracking_error_eu,
-                          0, (double)INT32_MAX + 1.0)) {
+  if (!ParseValCheckRange(node, "pos_tracking_error_eu",
+                          params_.pos_tracking_error_eu, 0,
+                          (double)INT32_MAX + 1.0)) {
     return false;
   }
 
@@ -84,8 +88,8 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
                           params_.peak_current_limit_amps, 0, 100)) {
     return false;
   }
-  if (!ParseValCheckRange(node, "peak_current_time_sec", params_.peak_current_time_sec,
-                          0, 60.0)) {
+  if (!ParseValCheckRange(node, "peak_current_time_sec",
+                          params_.peak_current_time_sec, 0, 60.0)) {
     return false;
   }
   if (!ParseValCheckRange(node, "continuous_current_limit_amps",
@@ -111,15 +115,16 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if (!ParseValCheckRange(node, "holding_duration_sec", params_.holding_duration_sec,
-                          0, 1000.0)) {
+  if (!ParseValCheckRange(node, "holding_duration_sec",
+                          params_.holding_duration_sec, 0, 1000.0)) {
     return false;
   }
 
   if (!ParseVal(node, "egd_brake_engage_msec", params_.egd_brake_engage_msec)) {
     return false;
   }
-  if (!ParseVal(node, "egd_brake_disengage_msec", params_.egd_brake_disengage_msec)) {
+  if (!ParseVal(node, "egd_brake_disengage_msec",
+                params_.egd_brake_disengage_msec)) {
     return false;
   }
   if (!ParseVal(node, "egd_crc", params_.egd_crc)) {
@@ -129,24 +134,30 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
                 params_.egd_drive_max_cur_limit_amps)) {
     return false;
   }
-  if (!ParseValCheckRange(node, "smooth_factor", params_.smooth_factor, -1, 64)) {
+  if (!ParseValCheckRange(node, "smooth_factor", params_.smooth_factor, -1,
+                          64)) {
     return false;
   }
-  
-  if (ParseOptValCheckRange(node, "torque_constant", params_.torque_constant, 0.0, 999999.0) &&
-      ParseOptValCheckRange(node, "winding_resistance", params_.winding_resistance, 0.0, 999999.0) ) {
-    
-    // Only compute power if we received both torque_constant and winding_resistance parameters
+
+  if (ParseOptValCheckRange(node, "torque_constant", params_.torque_constant,
+                            0.0, 999999.0) &&
+      ParseOptValCheckRange(node, "winding_resistance",
+                            params_.winding_resistance, 0.0, 999999.0)) {
+    // Only compute power if we received both torque_constant and
+    // winding_resistance parameters
     compute_power_ = true;
-    
+
     // Read in brake power (if provided) to add to actuator power
-    if (!ParseOptValCheckRange(node, "brake_power", params_.brake_power, 0.0, 9999.0)) {
+    if (!ParseOptValCheckRange(node, "brake_power", params_.brake_power, 0.0,
+                               9999.0)) {
       // If not found then set to zero
       params_.brake_power = 0.0;
     }
-    
-    // Read in any gear ratio between the motor and encoder for power calculation
-    if (!ParseOptValCheckRange(node, "motor_encoder_gear_ratio", params_.motor_encoder_gear_ratio, 0.0, 9999.0)) {
+
+    // Read in any gear ratio between the motor and encoder for power
+    // calculation
+    if (!ParseOptValCheckRange(node, "motor_encoder_gear_ratio",
+                               params_.motor_encoder_gear_ratio, 0.0, 9999.0)) {
       // If not found then set to 1.0
       params_.motor_encoder_gear_ratio = 1.0;
     }
@@ -164,7 +175,8 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
         JSD_EGD_GAIN_SCHEDULING_MODE_PRELOADED;
   }
 
-  if (!ParseOptVal(node, "absolute_encoder", params_.actuator_absolute_encoder)) {
+  if (!ParseOptVal(node, "absolute_encoder",
+                   params_.actuator_absolute_encoder)) {
     // If we do not find this parameter then set it to false
     params_.actuator_absolute_encoder = false;
   }
@@ -177,7 +189,8 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
 
   // overall_reduction must be set before using EuToCnts/CntsToEu
   if (actuator_type_ == ACTUATOR_TYPE_REVOLUTE) {
-    overall_reduction_ = params_.counts_per_rev * params_.gear_ratio / (2.0 * M_PI);
+    overall_reduction_ =
+        params_.counts_per_rev * params_.gear_ratio / (2.0 * M_PI);
 
   } else if (actuator_type_ == ACTUATOR_TYPE_PRISMATIC) {
     overall_reduction_ = params_.counts_per_rev * params_.gear_ratio;
@@ -194,12 +207,17 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
   jsd_slave_config_.product_code         = JSD_EGD_PRODUCT_CODE;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
-  jsd_slave_config_.egd.drive_cmd_mode    = JSD_EGD_DRIVE_CMD_MODE_CS;
-  jsd_slave_config_.egd.max_motor_speed   = EuToCnts(params_.max_speed_eu_per_sec);
-  jsd_slave_config_.egd.loop_period_ms    = round(loop_period_ * 1000.0); //elmo's interpolation time period should be slower than actual command loop
-  jsd_slave_config_.egd.torque_slope      = params_.torque_slope_amps_per_sec;
-  jsd_slave_config_.egd.max_profile_accel = EuToCnts(params_.max_accel_eu_per_sec2);
-  jsd_slave_config_.egd.max_profile_decel = EuToCnts(params_.max_accel_eu_per_sec2);
+  jsd_slave_config_.egd.drive_cmd_mode = JSD_EGD_DRIVE_CMD_MODE_CS;
+  jsd_slave_config_.egd.max_motor_speed =
+      EuToCnts(params_.max_speed_eu_per_sec);
+  jsd_slave_config_.egd.loop_period_ms =
+      round(loop_period_ * 1000.0);  // elmo's interpolation time period should
+                                     // be slower than actual command loop
+  jsd_slave_config_.egd.torque_slope = params_.torque_slope_amps_per_sec;
+  jsd_slave_config_.egd.max_profile_accel =
+      EuToCnts(params_.max_accel_eu_per_sec2);
+  jsd_slave_config_.egd.max_profile_decel =
+      EuToCnts(params_.max_accel_eu_per_sec2);
   jsd_slave_config_.egd.velocity_tracking_error =
       EuToCnts(params_.vel_tracking_error_eu_per_sec);
   jsd_slave_config_.egd.position_tracking_error =
@@ -213,13 +231,14 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
   jsd_slave_config_.egd.motor_stuck_timeout            = 0;  // disable
   jsd_slave_config_.egd.over_speed_threshold =
       params_.over_speed_multiplier * EuToCnts(params_.max_speed_eu_per_sec);
-  jsd_slave_config_.egd.low_position_limit      = 0;  // disable
-  jsd_slave_config_.egd.high_position_limit     = 0;  // disable
-  jsd_slave_config_.egd.brake_engage_msec       = params_.egd_brake_engage_msec;
-  jsd_slave_config_.egd.brake_disengage_msec    = params_.egd_brake_disengage_msec;
-  jsd_slave_config_.egd.crc                     = params_.egd_crc;
-  jsd_slave_config_.egd.drive_max_current_limit = params_.egd_drive_max_cur_limit_amps;
-  jsd_slave_config_.egd.smooth_factor           = params_.smooth_factor;
+  jsd_slave_config_.egd.low_position_limit   = 0;  // disable
+  jsd_slave_config_.egd.high_position_limit  = 0;  // disable
+  jsd_slave_config_.egd.brake_engage_msec    = params_.egd_brake_engage_msec;
+  jsd_slave_config_.egd.brake_disengage_msec = params_.egd_brake_disengage_msec;
+  jsd_slave_config_.egd.crc                  = params_.egd_crc;
+  jsd_slave_config_.egd.drive_max_current_limit =
+      params_.egd_drive_max_cur_limit_amps;
+  jsd_slave_config_.egd.smooth_factor = params_.smooth_factor;
 
   EgdSetConfig();
 
@@ -273,17 +292,16 @@ bool fastcat::Actuator::Read()
   state_->actuator_state.faulted = (actuator_sms_ == ACTUATOR_SMS_FAULTED);
 
   if (compute_power_) {
-    double motor_velocity =
-      fabs(state_->actuator_state.actual_velocity) *
-      params_.gear_ratio *
-      params_.motor_encoder_gear_ratio;
-    
+    double motor_velocity = fabs(state_->actuator_state.actual_velocity) *
+                            params_.gear_ratio *
+                            params_.motor_encoder_gear_ratio;
+
     double current = fabs(jsd_egd_state_.actual_current);
 
     // P = R I^2 + K_T * I * \omega
-    state_->actuator_state.power = current *
-      (params_.winding_resistance * current +
-       params_.torque_constant * motor_velocity);
+    state_->actuator_state.power =
+        current * (params_.winding_resistance * current +
+                   params_.torque_constant * motor_velocity);
 
     // Should check, but assuming motor_on > 0 means brakes powered/disengaged
     if (state_->actuator_state.motor_on) {
@@ -298,10 +316,9 @@ bool fastcat::Actuator::Read()
 
 bool fastcat::Actuator::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 
@@ -324,7 +341,8 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
       // This application may choose to set this during motions
       // in order to boost current during acceleration/deceleration
       // phases so don't check the state machine
-      params_.peak_current_limit_amps = cmd.actuator_set_max_current_cmd.current;
+      params_.peak_current_limit_amps =
+          cmd.actuator_set_max_current_cmd.current;
       EgdSetPeakCurrent(params_.peak_current_limit_amps);
       return true;
       break;
@@ -333,7 +351,7 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
       if (!HandleNewSetUnitModeCmd(cmd)) {
         ERROR("Failed to handle Set Unit Mode Command");
         return false;
-      } 
+      }
       return true;
       break;
 
@@ -379,7 +397,7 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         return false;
       }
       EgdSetGainSchedulingMode(
-          JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW, 
+          JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW,
           cmd.actuator_sdo_enable_manual_gain_scheduling_cmd.app_id);
       return true;
       break;
@@ -390,7 +408,7 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
         ERROR("Failed to handle Set Gain Scheduling Index Command");
         return false;
       }
-      EgdSetGainSchedulingIndex( 
+      EgdSetGainSchedulingIndex(
           cmd.actuator_set_gain_scheduling_index_cmd.gain_scheduling_index);
       return true;
       break;
@@ -399,14 +417,13 @@ bool fastcat::Actuator::Write(DeviceCmd& cmd)
       // no-op
       break;
   }
-  
 
   // Return early if a fault is active
-  // So as to not honor these motion commands when faulted 
-  if(device_fault_active_){
+  // So as to not honor these motion commands when faulted
+  if (device_fault_active_) {
     return false;
   }
-  
+
   switch (cmd.type) {
     case ACTUATOR_CSP_CMD:
       if (!HandleNewCSPCmd(cmd)) {
@@ -548,7 +565,7 @@ void fastcat::Actuator::Reset()
   WARNING("Resetting Actuator device %s", name_.c_str());
   if (actuator_sms_ == ACTUATOR_SMS_FAULTED) {
     // Resetting here would open brakes so we explicitly do not reset the EGD
-    // and instead only clear latched errors 
+    // and instead only clear latched errors
     EgdClearErrors();
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_OKAY;
     TransitionToState(ACTUATOR_SMS_HALTED);
@@ -566,7 +583,8 @@ bool fastcat::Actuator::SetOutputPosition(double position)
   return true;
 }
 
-bool fastcat::Actuator::HasAbsoluteEncoder(){
+bool fastcat::Actuator::HasAbsoluteEncoder()
+{
   return params_.actuator_absolute_encoder;
 }
 
@@ -768,17 +786,15 @@ void fastcat::Actuator::EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd)
 }
 
 void fastcat::Actuator::EgdSetGainSchedulingMode(
-    jsd_egd_gain_scheduling_mode_t mode, 
-    uint16_t app_id)
+    jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id)
 {
-  jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-      (jsd_t*)context_, slave_id_, mode, app_id);
+  jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode((jsd_t*)context_, slave_id_,
+                                                  mode, app_id);
 }
 
 void fastcat::Actuator::EgdSetGainSchedulingIndex(uint16_t index)
 {
-  jsd_egd_set_gain_scheduling_index(
-      (jsd_t*)context_, slave_id_, true, index);
+  jsd_egd_set_gain_scheduling_index((jsd_t*)context_, slave_id_, true, index);
 }
 
 bool fastcat::Actuator::GSModeFromString(

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -52,6 +52,8 @@ class Actuator : public JsdDeviceBase
 {
  public:
   Actuator();
+
+  
   bool      ConfigFromYaml(YAML::Node node) override;
   bool      Read() override;
   FaultType Process() override;
@@ -64,6 +66,38 @@ class Actuator : public JsdDeviceBase
   static std::string GetFastcatFaultCodeAsString(const DeviceState& state);
   static std::string GetJSDFaultCodeAsString(const DeviceState& state);
 
+  struct ActuatorParams {
+    std::string actuator_type_str;
+    double gear_ratio                     = 1;
+    double counts_per_rev                 = 1;
+    double max_speed_eu_per_sec           = 0;
+    double max_accel_eu_per_sec2          = 0;
+    double over_speed_multiplier          = 1;
+    double vel_tracking_error_eu_per_sec  = 0;
+    double pos_tracking_error_eu          = 0;
+    double peak_current_limit_amps        = 0;
+    double peak_current_time_sec          = 0;
+    double continuous_current_limit_amps  = 0;
+    double torque_slope_amps_per_sec      = 0;
+    double low_pos_cal_limit_eu           = 0;
+    double low_pos_cmd_limit_eu           = 0;
+    double high_pos_cmd_limit_eu          = 0;
+    double high_pos_cal_limit_eu          = 0;
+    double holding_duration_sec           = 0;
+    double egd_brake_engage_msec          = 0;
+    double egd_brake_disengage_msec       = 0;
+    double egd_crc                        = 0;
+    double egd_drive_max_cur_limit_amps   = 0;
+    double smooth_factor                  = 0;
+    double torque_constant                = 0;
+    double winding_resistance             = 0;
+    double brake_power                    = 0;
+    double motor_encoder_gear_ratio       = 0;
+    bool   actuator_absolute_encoder      = false;
+  };
+
+  const ActuatorParams& GetParams() { return params_; }
+ 
  protected:
   double  CntsToEu(int32_t cnts);
   int32_t EuToCnts(double eu);
@@ -124,34 +158,7 @@ class Actuator : public JsdDeviceBase
   virtual void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id);
   virtual void EgdSetGainSchedulingIndex(uint16_t index);
 
-  std::string  actuator_type_str_;
   ActuatorType actuator_type_;
-
-  double gear_ratio_                    = 1;
-  double counts_per_rev_                = 1;
-  double max_speed_eu_per_sec_          = 0;
-  double max_accel_eu_per_sec2_         = 0;
-  double over_speed_multiplier_         = 1;
-  double vel_tracking_error_eu_per_sec_ = 0;
-  double pos_tracking_error_eu_         = 0;
-  double peak_current_limit_amps_       = 0;
-  double peak_current_time_sec_         = 0;
-  double continuous_current_limit_amps_ = 0;
-  double torque_slope_amps_per_sec_     = 0;
-  double low_pos_cal_limit_eu_          = 0;
-  double low_pos_cmd_limit_eu_          = 0;
-  double high_pos_cmd_limit_eu_         = 0;
-  double high_pos_cal_limit_eu_         = 0;
-  double holding_duration_sec_          = 0;
-  double egd_brake_engage_msec_         = 0;
-  double egd_brake_disengage_msec_      = 0;
-  double egd_crc_                       = 0;
-  double egd_drive_max_cur_limit_amps_  = 0;
-  double smooth_factor_                 = 0;
-  double torque_constant_               = 0;
-  double winding_resistance_            = 0;
-  double brake_power_                   = 0;
-  double motor_encoder_gear_ratio_      = 0;
 
   bool compute_power_ = false;
 
@@ -167,6 +174,7 @@ class Actuator : public JsdDeviceBase
   int32_t                   egd_pos_offset_cnts_ = 1;
 
   ActuatorCalibrateCmd cal_cmd_;
+  ActuatorParams params_;
 
  private:
   bool GSModeFromString(std::string                     gs_mode_string,
@@ -174,7 +182,6 @@ class Actuator : public JsdDeviceBase
 
   bool prof_pos_hold_;
 
-  bool actuator_absolute_encoder_ = false;
 
   ActuatorFastcatFault fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_OKAY;
 };

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -53,7 +53,6 @@ class Actuator : public JsdDeviceBase
  public:
   Actuator();
 
-  
   bool      ConfigFromYaml(YAML::Node node) override;
   bool      Read() override;
   FaultType Process() override;
@@ -68,36 +67,36 @@ class Actuator : public JsdDeviceBase
 
   struct ActuatorParams {
     std::string actuator_type_str;
-    double gear_ratio                     = 1;
-    double counts_per_rev                 = 1;
-    double max_speed_eu_per_sec           = 0;
-    double max_accel_eu_per_sec2          = 0;
-    double over_speed_multiplier          = 1;
-    double vel_tracking_error_eu_per_sec  = 0;
-    double pos_tracking_error_eu          = 0;
-    double peak_current_limit_amps        = 0;
-    double peak_current_time_sec          = 0;
-    double continuous_current_limit_amps  = 0;
-    double torque_slope_amps_per_sec      = 0;
-    double low_pos_cal_limit_eu           = 0;
-    double low_pos_cmd_limit_eu           = 0;
-    double high_pos_cmd_limit_eu          = 0;
-    double high_pos_cal_limit_eu          = 0;
-    double holding_duration_sec           = 0;
-    double egd_brake_engage_msec          = 0;
-    double egd_brake_disengage_msec       = 0;
-    double egd_crc                        = 0;
-    double egd_drive_max_cur_limit_amps   = 0;
-    double smooth_factor                  = 0;
-    double torque_constant                = 0;
-    double winding_resistance             = 0;
-    double brake_power                    = 0;
-    double motor_encoder_gear_ratio       = 0;
-    bool   actuator_absolute_encoder      = false;
+    double      gear_ratio                    = 1;
+    double      counts_per_rev                = 1;
+    double      max_speed_eu_per_sec          = 0;
+    double      max_accel_eu_per_sec2         = 0;
+    double      over_speed_multiplier         = 1;
+    double      vel_tracking_error_eu_per_sec = 0;
+    double      pos_tracking_error_eu         = 0;
+    double      peak_current_limit_amps       = 0;
+    double      peak_current_time_sec         = 0;
+    double      continuous_current_limit_amps = 0;
+    double      torque_slope_amps_per_sec     = 0;
+    double      low_pos_cal_limit_eu          = 0;
+    double      low_pos_cmd_limit_eu          = 0;
+    double      high_pos_cmd_limit_eu         = 0;
+    double      high_pos_cal_limit_eu         = 0;
+    double      holding_duration_sec          = 0;
+    double      egd_brake_engage_msec         = 0;
+    double      egd_brake_disengage_msec      = 0;
+    double      egd_crc                       = 0;
+    double      egd_drive_max_cur_limit_amps  = 0;
+    double      smooth_factor                 = 0;
+    double      torque_constant               = 0;
+    double      winding_resistance            = 0;
+    double      brake_power                   = 0;
+    double      motor_encoder_gear_ratio      = 0;
+    bool        actuator_absolute_encoder     = false;
   };
 
   const ActuatorParams& GetParams() { return params_; }
- 
+
  protected:
   double  CntsToEu(int32_t cnts);
   int32_t EuToCnts(double eu);
@@ -155,7 +154,8 @@ class Actuator : public JsdDeviceBase
   virtual void EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd);
   virtual void EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd);
   virtual void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd);
-  virtual void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id);
+  virtual void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode,
+                                        uint16_t                       app_id);
   virtual void EgdSetGainSchedulingIndex(uint16_t index);
 
   ActuatorType actuator_type_;
@@ -174,14 +174,13 @@ class Actuator : public JsdDeviceBase
   int32_t                   egd_pos_offset_cnts_ = 1;
 
   ActuatorCalibrateCmd cal_cmd_;
-  ActuatorParams params_;
+  ActuatorParams       params_;
 
  private:
   bool GSModeFromString(std::string                     gs_mode_string,
                         jsd_egd_gain_scheduling_mode_t& gs_mode);
 
   bool prof_pos_hold_;
-
 
   ActuatorFastcatFault fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_OKAY;
 };

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -204,22 +204,19 @@ bool fastcat::Actuator::HandleNewProfPosCmd(DeviceCmd& cmd)
   }
 
   // Only transition to disengaging if its needed
-  if(state_->actuator_state.servo_enabled){
+  if (state_->actuator_state.servo_enabled) {
     // Bypassing wait since brakes are disengaged
-  }else{
+  } else {
     TransitionToState(ACTUATOR_SMS_PROF_POS_DISENGAGING);
     last_cmd_ = cmd;
     return true;
   }
 
-  trap_generate(
-      &trap_, state_->time,
-      state_->actuator_state.actual_position,
-      target_position,
-      state_->actuator_state.cmd_velocity,
-      cmd.actuator_prof_pos_cmd.end_velocity,
-      cmd.actuator_prof_pos_cmd.profile_velocity, // consider abs()
-      cmd.actuator_prof_pos_cmd.profile_accel);
+  trap_generate(&trap_, state_->time, state_->actuator_state.actual_position,
+                target_position, state_->actuator_state.cmd_velocity,
+                cmd.actuator_prof_pos_cmd.end_velocity,
+                cmd.actuator_prof_pos_cmd.profile_velocity,  // consider abs()
+                cmd.actuator_prof_pos_cmd.profile_accel);
 
   TransitionToState(ACTUATOR_SMS_PROF_POS);
   return true;
@@ -242,22 +239,20 @@ bool fastcat::Actuator::HandleNewProfVelCmd(DeviceCmd& cmd)
   }
 
   // Only transition to disengaging if its needed
-  if(state_->actuator_state.servo_enabled){
+  if (state_->actuator_state.servo_enabled) {
     // Bypassing wait since brakes are disengaged
-  }else{
+  } else {
     TransitionToState(ACTUATOR_SMS_PROF_VEL_DISENGAGING);
     last_cmd_ = cmd;
     return true;
   }
 
-
-  trap_generate_vel(
-      &trap_, state_->time,
-      state_->actuator_state.actual_position,
-      state_->actuator_state.cmd_velocity,
-      cmd.actuator_prof_vel_cmd.target_velocity,
-      cmd.actuator_prof_vel_cmd.profile_accel,
-      cmd.actuator_prof_vel_cmd.max_duration);
+  trap_generate_vel(&trap_, state_->time,
+                    state_->actuator_state.actual_position,
+                    state_->actuator_state.cmd_velocity,
+                    cmd.actuator_prof_vel_cmd.target_velocity,
+                    cmd.actuator_prof_vel_cmd.profile_accel,
+                    cmd.actuator_prof_vel_cmd.max_duration);
 
   TransitionToState(ACTUATOR_SMS_PROF_VEL);
   return true;
@@ -271,7 +266,7 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
     ERROR("Act %s: %s", name_.c_str(), "Failing Prof Torque Command");
     return false;
   }
-  
+
   // Check that the command can be honored within FSM state
   if (!CheckStateMachineMotionCmds()) {
     TransitionToState(ACTUATOR_SMS_FAULTED);
@@ -280,17 +275,18 @@ bool fastcat::Actuator::HandleNewProfTorqueCmd(DeviceCmd& cmd)
   }
 
   // Only transition to disengaging if its needed
-  if(state_->actuator_state.servo_enabled){
+  if (state_->actuator_state.servo_enabled) {
     // Bypassing wait since brakes are disengaged
-  }else{
+  } else {
     TransitionToState(ACTUATOR_SMS_PROF_TORQUE_DISENGAGING);
     last_cmd_ = cmd;
     return true;
   }
 
-  trap_generate_vel(
-      &trap_, state_->time, 0, 0, cmd.actuator_prof_torque_cmd.target_torque_amps,
-      params_.torque_slope_amps_per_sec, cmd.actuator_prof_torque_cmd.max_duration);
+  trap_generate_vel(&trap_, state_->time, 0, 0,
+                    cmd.actuator_prof_torque_cmd.target_torque_amps,
+                    params_.torque_slope_amps_per_sec,
+                    cmd.actuator_prof_torque_cmd.max_duration);
 
   TransitionToState(ACTUATOR_SMS_PROF_TORQUE);
   return true;
@@ -397,9 +393,8 @@ bool fastcat::Actuator::HandleNewSetUnitModeCmd(DeviceCmd& cmd)
       return false;
   }
 
-  EgdSetUnitMode(
-      cmd.actuator_sdo_set_unit_mode_cmd.mode,
-      cmd.actuator_sdo_set_unit_mode_cmd.app_id);
+  EgdSetUnitMode(cmd.actuator_sdo_set_unit_mode_cmd.mode,
+                 cmd.actuator_sdo_set_unit_mode_cmd.app_id);
 
   return true;
 }
@@ -454,18 +449,22 @@ bool fastcat::Actuator::HandleNewCalibrationCmd(DeviceCmd& cmd)
     return false;
   }
 
-  double rom = fabs(params_.high_pos_cal_limit_eu - params_.low_pos_cal_limit_eu);
+  double rom =
+      fabs(params_.high_pos_cal_limit_eu - params_.low_pos_cal_limit_eu);
   double cal_range = rom + params_.pos_tracking_error_eu;
 
-  // Since the hardstop calibration feature depends on a position tracking fault,
+  // Since the hardstop calibration feature depends on a position tracking
+  // fault,
   //   sanity check drive settings to prevent unexpected outcomes.
-  //   At the very least, the Range-of-Motion must be > the position tracking fault
-  //   tolerance. (In practice, ROM should be MUCH > than the full tracking tol)
-  if(rom < params_.pos_tracking_error_eu){
+  //   At the very least, the Range-of-Motion must be > the position tracking
+  //   fault tolerance. (In practice, ROM should be MUCH > than the full
+  //   tracking tol)
+  if (rom < params_.pos_tracking_error_eu) {
     TransitionToState(ACTUATOR_SMS_FAULTED);
-    ERROR("Act %s: Calibration cannot succeed when Range-of-motion (%lf) "
-          "< Pos tracking error (%lf). "
-          "Check Drive parameters for excessive pos tracking fault", 
+    ERROR(
+        "Act %s: Calibration cannot succeed when Range-of-motion (%lf) "
+        "< Pos tracking error (%lf). "
+        "Check Drive parameters for excessive pos tracking fault",
         name_.c_str(), rom, params_.pos_tracking_error_eu);
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_CAL_MOTION_RANGE;
     return false;
@@ -537,10 +536,7 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
   return false;
 }
 
-fastcat::FaultType fastcat::Actuator::ProcessFaulted()
-{
-  return NO_FAULT;
-}
+fastcat::FaultType fastcat::Actuator::ProcessFaulted() { return NO_FAULT; }
 
 fastcat::FaultType fastcat::Actuator::ProcessHalted()
 {
@@ -627,7 +623,7 @@ fastcat::FaultType fastcat::Actuator::ProcessProfTorque()
   jsd_egd_motion_command_cst_t jsd_cmd;
 
   double dummy_pos_eu, current;
-  int    complete = trap_update_vel(&trap_, state_->time, &dummy_pos_eu, &current);
+  int complete = trap_update_vel(&trap_, state_->time, &dummy_pos_eu, &current);
 
   jsd_cmd.target_torque_amps = current;
   jsd_cmd.torque_offset_amps = 0;
@@ -661,7 +657,8 @@ fastcat::FaultType fastcat::Actuator::ProcessCalMoveToHardstop()
     ERROR("Act %s: %s", name_.c_str(), "Fault Condition present, faulting");
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_STO_ENGAGED;
 
-    MSG("Restoring Current after calibration: %lf", params_.peak_current_limit_amps);
+    MSG("Restoring Current after calibration: %lf",
+        params_.peak_current_limit_amps);
     EgdSetPeakCurrent(params_.peak_current_limit_amps);
 
     return ALL_DEVICE_FAULT;
@@ -674,7 +671,8 @@ fastcat::FaultType fastcat::Actuator::ProcessCalMoveToHardstop()
         "Detected Hardstop, EGD jsd_fault_code",
         state_->actuator_state.jsd_fault_code);
 
-    MSG("Restoring Current after calibration: %lf", params_.peak_current_limit_amps);
+    MSG("Restoring Current after calibration: %lf",
+        params_.peak_current_limit_amps);
     EgdSetPeakCurrent(params_.peak_current_limit_amps);
 
     TransitionToState(ACTUATOR_SMS_CAL_AT_HARDSTOP);
@@ -698,7 +696,8 @@ fastcat::FaultType fastcat::Actuator::ProcessCalMoveToHardstop()
           "Moved Full Range and did not encounter hard stop");
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_NO_HARDSTOP_DURING_CAL;
 
-    MSG("Restoring Current after calibration: %lf", params_.peak_current_limit_amps);
+    MSG("Restoring Current after calibration: %lf",
+        params_.peak_current_limit_amps);
     EgdSetPeakCurrent(params_.peak_current_limit_amps);
 
     return ALL_DEVICE_FAULT;
@@ -770,35 +769,38 @@ fastcat::FaultType fastcat::Actuator::ProcessProfPosDisengaging()
     target_position = last_cmd_.actuator_prof_pos_cmd.target_position;
   }
 
-  if(state_->actuator_state.servo_enabled){
-    // If brakes are disengaged, setup the traps and transition to the execution state
+  if (state_->actuator_state.servo_enabled) {
+    // If brakes are disengaged, setup the traps and transition to the execution
+    // state
     trap_generate(
-        &trap_, state_->time,
-        state_->actuator_state.actual_position,
-        target_position,
-        state_->actuator_state.cmd_velocity,
+        &trap_, state_->time, state_->actuator_state.actual_position,
+        target_position, state_->actuator_state.cmd_velocity,
         last_cmd_.actuator_prof_pos_cmd.end_velocity,
-        last_cmd_.actuator_prof_pos_cmd.profile_velocity, // consider abs()
+        last_cmd_.actuator_prof_pos_cmd.profile_velocity,  // consider abs()
         last_cmd_.actuator_prof_pos_cmd.profile_accel);
 
     TransitionToState(ACTUATOR_SMS_PROF_POS);
 
-  }else{
-    // Otherwise, command the current position to trigger the transition and wait
+  } else {
+    // Otherwise, command the current position to trigger the transition and
+    // wait
 
     jsd_egd_motion_command_csp_t jsd_cmd;
 
-    jsd_cmd.target_position    = PosEuToCnts(state_->actuator_state.actual_position);
+    jsd_cmd.target_position =
+        PosEuToCnts(state_->actuator_state.actual_position);
     jsd_cmd.position_offset    = 0;
     jsd_cmd.velocity_offset    = 0;
     jsd_cmd.torque_offset_amps = 0;
 
     EgdCSP(jsd_cmd);
 
-    // Check runout timer here, brake engage/disengage time cannot exceed 1 second
-    // per MAN-G-CR Section BP - Brake Parameters
-    if( (jsd_time_get_time_sec() - last_transition_time_) > (1.0 + 2*loop_period_)){
-      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting", name_.c_str());
+    // Check runout timer here, brake engage/disengage time cannot exceed 1
+    // second per MAN-G-CR Section BP - Brake Parameters
+    if ((jsd_time_get_time_sec() - last_transition_time_) >
+        (1.0 + 2 * loop_period_)) {
+      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
+            name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
       return ALL_DEVICE_FAULT;
     }
@@ -814,20 +816,21 @@ fastcat::FaultType fastcat::Actuator::ProcessProfVelDisengaging()
     return ALL_DEVICE_FAULT;
   }
 
-  if(state_->actuator_state.servo_enabled){
-    // If brakes are disengaged, setup the traps and transition to the execution state
-  trap_generate_vel(
-      &trap_, state_->time,
-      state_->actuator_state.actual_position,
-      state_->actuator_state.cmd_velocity,
-      last_cmd_.actuator_prof_vel_cmd.target_velocity,
-      last_cmd_.actuator_prof_vel_cmd.profile_accel,
-      last_cmd_.actuator_prof_vel_cmd.max_duration);
+  if (state_->actuator_state.servo_enabled) {
+    // If brakes are disengaged, setup the traps and transition to the execution
+    // state
+    trap_generate_vel(&trap_, state_->time,
+                      state_->actuator_state.actual_position,
+                      state_->actuator_state.cmd_velocity,
+                      last_cmd_.actuator_prof_vel_cmd.target_velocity,
+                      last_cmd_.actuator_prof_vel_cmd.profile_accel,
+                      last_cmd_.actuator_prof_vel_cmd.max_duration);
 
-  TransitionToState(ACTUATOR_SMS_PROF_VEL);
+    TransitionToState(ACTUATOR_SMS_PROF_VEL);
 
-  }else{
-    // Otherwise, command the current position to trigger the transition and wait
+  } else {
+    // Otherwise, command the current position to trigger the transition and
+    // wait
     jsd_egd_motion_command_csv_t jsd_cmd;
 
     jsd_cmd.target_velocity    = 0;
@@ -836,10 +839,12 @@ fastcat::FaultType fastcat::Actuator::ProcessProfVelDisengaging()
 
     EgdCSV(jsd_cmd);
 
-    // Check runout timer here, brake engage/disengage time cannot exceed 1 second
-    // per MAN-G-CR Section BP - Brake Parameters
-    if( (jsd_time_get_time_sec() - last_transition_time_) > (1.0 + 2*loop_period_)){
-      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting", name_.c_str());
+    // Check runout timer here, brake engage/disengage time cannot exceed 1
+    // second per MAN-G-CR Section BP - Brake Parameters
+    if ((jsd_time_get_time_sec() - last_transition_time_) >
+        (1.0 + 2 * loop_period_)) {
+      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
+            name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
       return ALL_DEVICE_FAULT;
     }
@@ -855,16 +860,19 @@ fastcat::FaultType fastcat::Actuator::ProcessProfTorqueDisengaging()
     return ALL_DEVICE_FAULT;
   }
 
-  if(state_->actuator_state.servo_enabled){
-    // If brakes are disengaged, setup the traps and transition to the execution state
-    trap_generate_vel(
-        &trap_, state_->time, 0, 0, last_cmd_.actuator_prof_torque_cmd.target_torque_amps,
-        params_.torque_slope_amps_per_sec, last_cmd_.actuator_prof_torque_cmd.max_duration);
+  if (state_->actuator_state.servo_enabled) {
+    // If brakes are disengaged, setup the traps and transition to the execution
+    // state
+    trap_generate_vel(&trap_, state_->time, 0, 0,
+                      last_cmd_.actuator_prof_torque_cmd.target_torque_amps,
+                      params_.torque_slope_amps_per_sec,
+                      last_cmd_.actuator_prof_torque_cmd.max_duration);
 
     TransitionToState(ACTUATOR_SMS_PROF_TORQUE);
 
-  }else{
-    // Otherwise, command the current position to trigger the transition and wait
+  } else {
+    // Otherwise, command the current position to trigger the transition and
+    // wait
     jsd_egd_motion_command_cst_t jsd_cmd;
 
     jsd_cmd.target_torque_amps = 0;
@@ -872,10 +880,12 @@ fastcat::FaultType fastcat::Actuator::ProcessProfTorqueDisengaging()
 
     EgdCST(jsd_cmd);
 
-    // Check runout timer here, brake engage/disengage time cannot exceed 1 second
-    // per MAN-G-CR Section BP - Brake Parameters
-    if( (jsd_time_get_time_sec() - last_transition_time_) > (1.0 + 2*loop_period_)){
-      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting", name_.c_str());
+    // Check runout timer here, brake engage/disengage time cannot exceed 1
+    // second per MAN-G-CR Section BP - Brake Parameters
+    if ((jsd_time_get_time_sec() - last_transition_time_) >
+        (1.0 + 2 * loop_period_)) {
+      ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
+            name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
       return ALL_DEVICE_FAULT;
     }

--- a/src/jsd/actuator_offline.cc
+++ b/src/jsd/actuator_offline.cc
@@ -58,7 +58,7 @@ void fastcat::ActuatorOffline::EgdProcess()
   // 
   if(!jsd_egd_state_.servo_enabled and jsd_egd_state_.motor_on){
     double brake_on_dur = jsd_time_get_time_sec() - motor_on_start_time_;
-    if(brake_on_dur > egd_brake_disengage_msec_/1000.0){
+    if(brake_on_dur > params_.egd_brake_disengage_msec / 1000.0){
       jsd_egd_state_.servo_enabled = 1;
     }
   }
@@ -135,7 +135,7 @@ void fastcat::ActuatorOffline::EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd)
   jsd_egd_state_.cmd_ff_velocity = jsd_csv_cmd.velocity_offset;
   jsd_egd_state_.cmd_ff_current  = jsd_csv_cmd.torque_offset_amps;
 
-  // simulate actuals
+  // simulate velocity
   jsd_egd_state_.actual_velocity =
       jsd_egd_state_.cmd_velocity + jsd_egd_state_.cmd_ff_velocity;
   jsd_egd_state_.actual_current =
@@ -154,15 +154,15 @@ void fastcat::ActuatorOffline::EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd)
   jsd_egd_state_.cmd_ff_velocity = 0;
   jsd_egd_state_.cmd_ff_current  = jsd_cst_cmd.torque_offset_amps;
 
-  // simulate actuals
+  // simulate position and velocity
   jsd_egd_state_.actual_position =
       jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position;
   jsd_egd_state_.actual_current =
       jsd_egd_state_.cmd_current + jsd_egd_state_.cmd_ff_current;
 
-  double pct = jsd_egd_state_.actual_current / continuous_current_limit_amps_;
+  double pct = jsd_egd_state_.actual_current / params_.continuous_current_limit_amps;
   jsd_egd_state_.actual_velocity =
-      pct * max_speed_eu_per_sec_;  // sure, why not
+      pct * params_.max_speed_eu_per_sec;
   jsd_egd_state_.actual_position +=
       jsd_egd_state_.actual_velocity * loop_period_;  // integrated
 }

--- a/src/jsd/actuator_offline.cc
+++ b/src/jsd/actuator_offline.cc
@@ -32,7 +32,7 @@ void fastcat::ActuatorOffline::EgdProcess()
   switch (actuator_sms_) {
     case ACTUATOR_SMS_FAULTED:
     case ACTUATOR_SMS_HALTED:
-      jsd_egd_state_.motor_on = 0;
+      jsd_egd_state_.motor_on      = 0;
       jsd_egd_state_.servo_enabled = 0;
       break;
 
@@ -50,15 +50,15 @@ void fastcat::ActuatorOffline::EgdProcess()
   }
 
   // reset motor_on timer on rising edge
-  if(!last_motor_on_state_ and jsd_egd_state_.motor_on){
+  if (!last_motor_on_state_ and jsd_egd_state_.motor_on) {
     motor_on_start_time_ = jsd_time_get_time_sec();
   }
   last_motor_on_state_ = jsd_egd_state_.motor_on;
 
-  // 
-  if(!jsd_egd_state_.servo_enabled and jsd_egd_state_.motor_on){
+  //
+  if (!jsd_egd_state_.servo_enabled and jsd_egd_state_.motor_on) {
     double brake_on_dur = jsd_time_get_time_sec() - motor_on_start_time_;
-    if(brake_on_dur > params_.egd_brake_disengage_msec / 1000.0){
+    if (brake_on_dur > params_.egd_brake_disengage_msec / 1000.0) {
       jsd_egd_state_.servo_enabled = 1;
     }
   }
@@ -91,8 +91,7 @@ void fastcat::ActuatorOffline::EgdSetUnitMode(int32_t mode, uint16_t app_id)
 }
 
 void fastcat::ActuatorOffline::EgdSetGainSchedulingMode(
-    jsd_egd_gain_scheduling_mode_t /* mode */,
-    uint16_t /* app_id */)
+    jsd_egd_gain_scheduling_mode_t /* mode */, uint16_t /* app_id */)
 {
   // no-op
 }
@@ -113,16 +112,17 @@ void fastcat::ActuatorOffline::EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd)
   jsd_egd_state_.cmd_ff_current  = jsd_csp_cmd.torque_offset_amps;
 
   // Differentiate position to get actual_velocity
-  double vel = (jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position
-                - jsd_egd_state_.actual_position) / loop_period_;
+  double vel = (jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position -
+                jsd_egd_state_.actual_position) /
+               loop_period_;
 
   // simulate actuals
   jsd_egd_state_.actual_position =
       jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position;
   jsd_egd_state_.actual_current =
       jsd_egd_state_.cmd_current + jsd_egd_state_.cmd_ff_current;
-  
-  jsd_egd_state_.actual_velocity = vel; // "sure, why not"
+
+  jsd_egd_state_.actual_velocity = vel;  // "sure, why not"
 }
 
 void fastcat::ActuatorOffline::EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd)
@@ -160,9 +160,9 @@ void fastcat::ActuatorOffline::EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd)
   jsd_egd_state_.actual_current =
       jsd_egd_state_.cmd_current + jsd_egd_state_.cmd_ff_current;
 
-  double pct = jsd_egd_state_.actual_current / params_.continuous_current_limit_amps;
-  jsd_egd_state_.actual_velocity =
-      pct * params_.max_speed_eu_per_sec;
+  double pct =
+      jsd_egd_state_.actual_current / params_.continuous_current_limit_amps;
+  jsd_egd_state_.actual_velocity = pct * params_.max_speed_eu_per_sec;
   jsd_egd_state_.actual_position +=
       jsd_egd_state_.actual_velocity * loop_period_;  // integrated
 }

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -27,10 +27,11 @@ class ActuatorOffline : public Actuator
   void EgdCSP(jsd_egd_motion_command_csp_t jsd_csp_cmd) override;
   void EgdCSV(jsd_egd_motion_command_csv_t jsd_csv_cmd) override;
   void EgdCST(jsd_egd_motion_command_cst_t jsd_cst_cmd) override;
-  void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode, uint16_t app_id) override;
+  void EgdSetGainSchedulingMode(jsd_egd_gain_scheduling_mode_t mode,
+                                uint16_t                       app_id) override;
   void EgdSetGainSchedulingIndex(uint16_t index) override;
 
-  double motor_on_start_time_;
+  double  motor_on_start_time_;
   uint8_t last_motor_on_state_;
 };
 

--- a/src/jsd/ati_fts.cc
+++ b/src/jsd/ati_fts.cc
@@ -34,10 +34,12 @@ bool fastcat::AtiFts::ConfigFromYamlCommon(YAML::Node node)
 
   double dummy;
   if (ParseOptVal(node, "max_force", dummy)) {
-    ERROR("fastcat no longer accept L2 norm, configure your yaml values per axis");
+    ERROR(
+        "fastcat no longer accept L2 norm, configure your yaml values per "
+        "axis");
     return false;
   }
-  
+
   if (!ParseVal(node, "max_force_x", max_force_[0])) {
     return false;
   }
@@ -110,20 +112,23 @@ fastcat::FaultType fastcat::AtiFts::Process()
       return ALL_DEVICE_FAULT;
     }
 
-    if(enable_fts_guard_fault_){
-      if (max_force_[0] < fabs(state_->fts_state.raw_fx) || max_force_[1] < fabs(state_->fts_state.raw_fy) || max_force_[2] < fabs(state_->fts_state.raw_fz) ||
-        max_torque_[0] < fabs(state_->fts_state.raw_tx) || max_torque_[1] < fabs(state_->fts_state.raw_ty) || max_torque_[2] < fabs(state_->fts_state.raw_tz)) {
-          ERROR(
+    if (enable_fts_guard_fault_) {
+      if (max_force_[0] < fabs(state_->fts_state.raw_fx) ||
+          max_force_[1] < fabs(state_->fts_state.raw_fy) ||
+          max_force_[2] < fabs(state_->fts_state.raw_fz) ||
+          max_torque_[0] < fabs(state_->fts_state.raw_tx) ||
+          max_torque_[1] < fabs(state_->fts_state.raw_ty) ||
+          max_torque_[2] < fabs(state_->fts_state.raw_tz)) {
+        ERROR(
             "Force or torque measured by device %s exceeded maximum allowable "
             "magnitude. Force: [x]: %f / %f, [y]: %f / %f, [z]: %f / %f "
             "Torque: [x]: %f / %f, [y]: %f / %f, [z]: %f / %f",
             name_.c_str(), state_->fts_state.raw_fx, max_force_[0],
-            state_->fts_state.raw_fy, max_force_[1],
-            state_->fts_state.raw_fz, max_force_[2],
-            state_->fts_state.raw_tx, max_torque_[0],
-            state_->fts_state.raw_ty, max_torque_[1],
-            state_->fts_state.raw_tz, max_torque_[2]);
-          return ALL_DEVICE_FAULT;
+            state_->fts_state.raw_fy, max_force_[1], state_->fts_state.raw_fz,
+            max_force_[2], state_->fts_state.raw_tx, max_torque_[0],
+            state_->fts_state.raw_ty, max_torque_[1], state_->fts_state.raw_tz,
+            max_torque_[2]);
+        return ALL_DEVICE_FAULT;
       }
     }
   }
@@ -133,20 +138,19 @@ fastcat::FaultType fastcat::AtiFts::Process()
 
 bool fastcat::AtiFts::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 
   if (cmd.type == FTS_TARE_CMD) {
-
     // Do not permit taring if there is a fault
-    if(device_fault_active_){
-      ERROR("Taring (%s) FTS is not permited with an active fault, reset first", name_.c_str());
+    if (device_fault_active_) {
+      ERROR("Taring (%s) FTS is not permited with an active fault, reset first",
+            name_.c_str());
       return false;
-    }else{
+    } else {
       bias_[0] = -state_->fts_state.raw_fx;
       bias_[1] = -state_->fts_state.raw_fy;
       bias_[2] = -state_->fts_state.raw_fz;
@@ -155,14 +159,11 @@ bool fastcat::AtiFts::Write(DeviceCmd& cmd)
       bias_[5] = -state_->fts_state.raw_tz;
       return true;
     }
-  }
-  else if (cmd.type == FTS_ENABLE_GUARD_FAULT_CMD) {
+  } else if (cmd.type == FTS_ENABLE_GUARD_FAULT_CMD) {
     enable_fts_guard_fault_ = cmd.fts_enable_guard_fault_cmd.enable;
     return true;
-  }
-  else{
+  } else {
     WARNING("That command type is not supported!");
     return false;
   }
-
 }

--- a/src/jsd/ati_fts.h
+++ b/src/jsd/ati_fts.h
@@ -30,9 +30,9 @@ class AtiFts : public JsdDeviceBase
 
   double bias_[6] = {0};
 
-  bool enable_fts_guard_fault_ = true;
-  double max_force_[3]  = {0, 0, 0};
-  double max_torque_[3] = {0, 0, 0};
+  bool   enable_fts_guard_fault_ = true;
+  double max_force_[3]           = {0, 0, 0};
+  double max_torque_[3]          = {0, 0, 0};
 };
 
 }  // namespace fastcat

--- a/src/jsd/ati_fts_offline.cc
+++ b/src/jsd/ati_fts_offline.cc
@@ -10,9 +10,6 @@ bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node)
   return ConfigFromYamlCommon(node);
 }
 
-bool fastcat::AtiFtsOffline::Read()
-{
-  return true;
-}
+bool fastcat::AtiFtsOffline::Read() { return true; }
 
 fastcat::FaultType fastcat::AtiFtsOffline::Process() { return NO_FAULT; }

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -48,17 +48,17 @@ bool fastcat::Egd::Read()
   state_->egd_state.actual_mode_of_operation =
       static_cast<uint32_t>(jsd_egd_state_.actual_mode_of_operation);
 
-  state_->egd_state.sto_engaged          = jsd_egd_state_.sto_engaged;
-  state_->egd_state.hall_state           = jsd_egd_state_.hall_state;
-  state_->egd_state.in_motion            = jsd_egd_state_.in_motion;
-  state_->egd_state.warning              = jsd_egd_state_.warning;
-  state_->egd_state.target_reached       = jsd_egd_state_.target_reached;
-  state_->egd_state.motor_on             = jsd_egd_state_.motor_on;
-  state_->egd_state.servo_enabled        = jsd_egd_state_.servo_enabled;
+  state_->egd_state.sto_engaged    = jsd_egd_state_.sto_engaged;
+  state_->egd_state.hall_state     = jsd_egd_state_.hall_state;
+  state_->egd_state.in_motion      = jsd_egd_state_.in_motion;
+  state_->egd_state.warning        = jsd_egd_state_.warning;
+  state_->egd_state.target_reached = jsd_egd_state_.target_reached;
+  state_->egd_state.motor_on       = jsd_egd_state_.motor_on;
+  state_->egd_state.servo_enabled  = jsd_egd_state_.servo_enabled;
 
   state_->egd_state.emcy_error_code = jsd_egd_state_.emcy_error_code;
-  state_->egd_state.fault_code = 
-    static_cast<uint32_t>(jsd_egd_state_.fault_code);
+  state_->egd_state.fault_code =
+      static_cast<uint32_t>(jsd_egd_state_.fault_code);
 
   state_->egd_state.bus_voltage          = jsd_egd_state_.bus_voltage;
   state_->egd_state.analog_input_voltage = jsd_egd_state_.analog_input_voltage;
@@ -99,7 +99,7 @@ bool fastcat::Egd::Write(DeviceCmd& cmd)
 {
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 
@@ -313,8 +313,7 @@ bool fastcat::Egd::WriteProfiledMode(DeviceCmd& cmd)
       jsd_egd_motion_command_prof_torque_t jsd_cmd;
       jsd_cmd.target_torque_amps = cmd.egd_prof_torque_cmd.target_torque_amps;
 
-      jsd_egd_set_motion_command_prof_torque(context_, slave_id_,
-                                             jsd_cmd);
+      jsd_egd_set_motion_command_prof_torque(context_, slave_id_, jsd_cmd);
       break;
     }
     case EGD_RESET_CMD: {
@@ -327,43 +326,37 @@ bool fastcat::Egd::WriteProfiledMode(DeviceCmd& cmd)
     }
     case EGD_SDO_SET_DRIVE_POS_CMD: {
       jsd_egd_async_sdo_set_drive_position(
-          context_, slave_id_,
-          cmd.egd_sdo_set_drive_pos_cmd.drive_position,
+          context_, slave_id_, cmd.egd_sdo_set_drive_pos_cmd.drive_position,
           cmd.egd_sdo_set_drive_pos_cmd.app_id);
       break;
     }
     case EGD_SDO_SET_UNIT_MODE_CMD: {
-      jsd_egd_async_sdo_set_unit_mode(
-          context_, slave_id_,
-          cmd.egd_sdo_set_unit_mode_cmd.unit_mode,
-          cmd.egd_sdo_set_unit_mode_cmd.app_id);
+      jsd_egd_async_sdo_set_unit_mode(context_, slave_id_,
+                                      cmd.egd_sdo_set_unit_mode_cmd.unit_mode,
+                                      cmd.egd_sdo_set_unit_mode_cmd.app_id);
       break;
     }
     case EGD_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED,
           cmd.egd_sdo_disable_gain_scheduling_cmd.app_id);
       break;
     }
     case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_SPEED,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_SPEED,
           cmd.egd_sdo_enable_speed_gain_scheduling_cmd.app_id);
       break;
     }
     case EGD_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_POSITION,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_POSITION,
           cmd.egd_sdo_enable_position_gain_scheduling_cmd.app_id);
       break;
     }
     case EGD_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW,
           cmd.egd_sdo_enable_position_gain_scheduling_cmd.app_id);
       break;
     }
@@ -421,43 +414,37 @@ bool fastcat::Egd::WriteCSMode(DeviceCmd& cmd)
     }
     case EGD_SDO_SET_DRIVE_POS_CMD: {
       jsd_egd_async_sdo_set_drive_position(
-          context_, slave_id_,
-          cmd.egd_sdo_set_drive_pos_cmd.drive_position,
+          context_, slave_id_, cmd.egd_sdo_set_drive_pos_cmd.drive_position,
           cmd.egd_sdo_set_drive_pos_cmd.app_id);
       break;
     }
     case EGD_SDO_SET_UNIT_MODE_CMD: {
-      jsd_egd_async_sdo_set_unit_mode(
-          context_, slave_id_,
-          cmd.egd_sdo_set_unit_mode_cmd.unit_mode,
-          cmd.egd_sdo_set_unit_mode_cmd.app_id);
+      jsd_egd_async_sdo_set_unit_mode(context_, slave_id_,
+                                      cmd.egd_sdo_set_unit_mode_cmd.unit_mode,
+                                      cmd.egd_sdo_set_unit_mode_cmd.app_id);
       break;
     }
     case EGD_SDO_DISABLE_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_DISABLED,
           cmd.egd_sdo_disable_gain_scheduling_cmd.app_id);
       break;
     }
     case EGD_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_SPEED,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_SPEED,
           cmd.egd_sdo_enable_speed_gain_scheduling_cmd.app_id);
       break;
     }
     case EGD_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_POSITION,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_POSITION,
           cmd.egd_sdo_enable_position_gain_scheduling_cmd.app_id);
       break;
     }
     case EGD_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD: {
       jsd_egd_async_sdo_set_ctrl_gain_scheduling_mode(
-          context_, slave_id_, 
-          JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW,
+          context_, slave_id_, JSD_EGD_GAIN_SCHEDULING_MODE_MANUAL_LOW,
           cmd.egd_sdo_enable_position_gain_scheduling_cmd.app_id);
       break;
     }

--- a/src/jsd/egd_offline.cc
+++ b/src/jsd/egd_offline.cc
@@ -58,10 +58,9 @@ fastcat::FaultType fastcat::EgdOffline::Process()
 
 bool fastcat::EgdOffline::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/el2124.cc
+++ b/src/jsd/el2124.cc
@@ -62,7 +62,7 @@ bool fastcat::El2124::Write(DeviceCmd& cmd)
 {
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/el2124_offline.cc
+++ b/src/jsd/el2124_offline.cc
@@ -15,10 +15,7 @@ bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node)
   return ConfigFromYamlCommon(node);
 }
 
-bool fastcat::El2124Offline::Read()
-{
-  return true;
-}
+bool fastcat::El2124Offline::Read() { return true; }
 
 fastcat::FaultType fastcat::El2124Offline::Process()
 {
@@ -27,10 +24,9 @@ fastcat::FaultType fastcat::El2124Offline::Process()
 
 bool fastcat::El2124Offline::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/el3104_offline.cc
+++ b/src/jsd/el3104_offline.cc
@@ -14,7 +14,4 @@ bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node)
   return ConfigFromYamlCommon(node);
 }
 
-bool fastcat::El3104Offline::Read()
-{
-  return true;
-}
+bool fastcat::El3104Offline::Read() { return true; }

--- a/src/jsd/el3202.cc
+++ b/src/jsd/el3202.cc
@@ -52,14 +52,14 @@ bool fastcat::El3202::ConfigFromYamlCommon(YAML::Node node)
     return false;
   }
 
-  //TODO: Should all config put in fcat_config.yaml??
+  // TODO: Should all config put in fcat_config.yaml??
   jsd_slave_config_.el3202.element[0] = element_ch1_;
   jsd_slave_config_.el3202.element[1] = element_ch2_;
 
-  jsd_slave_config_.el3202.filter[0] = JSD_BECKHOFF_FILTER_50HZ;
-  jsd_slave_config_.el3202.filter[1] = JSD_BECKHOFF_FILTER_50HZ;
-  jsd_slave_config_.el3202.connection[0] = JSD_EL3202_CONNECTION_4WIRE;
-  jsd_slave_config_.el3202.connection[1] = JSD_EL3202_CONNECTION_4WIRE;
+  jsd_slave_config_.el3202.filter[0]       = JSD_BECKHOFF_FILTER_50HZ;
+  jsd_slave_config_.el3202.filter[1]       = JSD_BECKHOFF_FILTER_50HZ;
+  jsd_slave_config_.el3202.connection[0]   = JSD_EL3202_CONNECTION_4WIRE;
+  jsd_slave_config_.el3202.connection[1]   = JSD_EL3202_CONNECTION_4WIRE;
   jsd_slave_config_.el3202.presentation[0] = JSD_EL3202_PRESENTATION_SIGNED;
   jsd_slave_config_.el3202.presentation[1] = JSD_EL3202_PRESENTATION_SIGNED;
   return true;
@@ -72,16 +72,16 @@ bool fastcat::El3202::Read()
   const jsd_el3202_state_t* jsd_state =
       jsd_el3202_get_state((jsd_t*)context_, slave_id_);
 
-  state_->el3202_state.output_eu_ch1   = jsd_state->output_eu[0];
-  state_->el3202_state.output_eu_ch2   = jsd_state->output_eu[1];
+  state_->el3202_state.output_eu_ch1 = jsd_state->output_eu[0];
+  state_->el3202_state.output_eu_ch2 = jsd_state->output_eu[1];
   state_->el3202_state.adc_value_ch1 = jsd_state->adc_value[0];
   state_->el3202_state.adc_value_ch2 = jsd_state->adc_value[1];
 
   return true;
 }
 
-bool fastcat::El3202::ElementFromString(std::string element_string,
-                                      jsd_el3202_element_t& element)
+bool fastcat::El3202::ElementFromString(std::string           element_string,
+                                        jsd_el3202_element_t& element)
 {
   MSG("Converting element to string.");
   if (element_string.compare("PT100") == 0) {

--- a/src/jsd/el3202.h
+++ b/src/jsd/el3202.h
@@ -19,10 +19,11 @@ class El3202 : public JsdDeviceBase
   bool Read() override;
 
  protected:
-  bool ConfigFromYamlCommon(YAML::Node node);
-  bool ElementFromString(std::string element_string, jsd_el3202_element_t& element);
-  std::string        element_ch1_string_;
-  std::string        element_ch2_string_;
+  bool                 ConfigFromYamlCommon(YAML::Node node);
+  bool                 ElementFromString(std::string           element_string,
+                                         jsd_el3202_element_t& element);
+  std::string          element_ch1_string_;
+  std::string          element_ch2_string_;
   jsd_el3202_element_t element_ch1_{JSD_EL3202_ELEMENT_PT100};
   jsd_el3202_element_t element_ch2_{JSD_EL3202_ELEMENT_PT100};
 

--- a/src/jsd/el3202_offline.cc
+++ b/src/jsd/el3202_offline.cc
@@ -14,7 +14,4 @@ bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node)
   return ConfigFromYamlCommon(node);
 }
 
-bool fastcat::El3202Offline::Read()
-{
-  return true;
-}
+bool fastcat::El3202Offline::Read() { return true; }

--- a/src/jsd/el3318.cc
+++ b/src/jsd/el3318.cc
@@ -45,9 +45,9 @@ bool fastcat::El3318::ConfigFromYamlCommon(YAML::Node node)
   }
 
   int i;
-  for(i=0; i < JSD_EL3318_NUM_CHANNELS; i++) {
-    jsd_slave_config_.el3318.element[i] = element_;
-    jsd_slave_config_.el3318.filter[i] = JSD_BECKHOFF_FILTER_50HZ;
+  for (i = 0; i < JSD_EL3318_NUM_CHANNELS; i++) {
+    jsd_slave_config_.el3318.element[i]      = element_;
+    jsd_slave_config_.el3318.filter[i]       = JSD_BECKHOFF_FILTER_50HZ;
     jsd_slave_config_.el3318.presentation[i] = JSD_EL3318_PRESENTATION_SIGNED;
   }
 
@@ -61,14 +61,14 @@ bool fastcat::El3318::Read()
   const jsd_el3318_state_t* jsd_state =
       jsd_el3318_get_state((jsd_t*)context_, slave_id_);
 
-  state_->el3318_state.output_eu_ch1   = jsd_state->output_eu[0];
-  state_->el3318_state.output_eu_ch2   = jsd_state->output_eu[1];
-  state_->el3318_state.output_eu_ch3   = jsd_state->output_eu[2];
-  state_->el3318_state.output_eu_ch4   = jsd_state->output_eu[3];
-  state_->el3318_state.output_eu_ch5   = jsd_state->output_eu[4];
-  state_->el3318_state.output_eu_ch6   = jsd_state->output_eu[5];
-  state_->el3318_state.output_eu_ch7   = jsd_state->output_eu[6];
-  state_->el3318_state.output_eu_ch8   = jsd_state->output_eu[7];
+  state_->el3318_state.output_eu_ch1 = jsd_state->output_eu[0];
+  state_->el3318_state.output_eu_ch2 = jsd_state->output_eu[1];
+  state_->el3318_state.output_eu_ch3 = jsd_state->output_eu[2];
+  state_->el3318_state.output_eu_ch4 = jsd_state->output_eu[3];
+  state_->el3318_state.output_eu_ch5 = jsd_state->output_eu[4];
+  state_->el3318_state.output_eu_ch6 = jsd_state->output_eu[5];
+  state_->el3318_state.output_eu_ch7 = jsd_state->output_eu[6];
+  state_->el3318_state.output_eu_ch8 = jsd_state->output_eu[7];
   state_->el3318_state.adc_value_ch1 = jsd_state->adc_value[0];
   state_->el3318_state.adc_value_ch2 = jsd_state->adc_value[1];
   state_->el3318_state.adc_value_ch3 = jsd_state->adc_value[2];
@@ -81,7 +81,7 @@ bool fastcat::El3318::Read()
   return true;
 }
 
-bool fastcat::El3318::ElementFromString(std::string element_string,
+bool fastcat::El3318::ElementFromString(std::string           element_string,
                                         jsd_el3318_element_t& element)
 {
   MSG("Converting element to string.");

--- a/src/jsd/el3318.h
+++ b/src/jsd/el3318.h
@@ -19,9 +19,10 @@ class El3318 : public JsdDeviceBase
   bool Read() override;
 
  protected:
-  bool ConfigFromYamlCommon(YAML::Node node);
-  bool ElementFromString(std::string element_string, jsd_el3318_element_t& element);
-  std::string        element_string_;
+  bool                 ConfigFromYamlCommon(YAML::Node node);
+  bool                 ElementFromString(std::string           element_string,
+                                         jsd_el3318_element_t& element);
+  std::string          element_string_;
   jsd_el3318_element_t element_{JSD_EL3318_ELEMENT_TYPE_K};
 
  private:

--- a/src/jsd/el3318_offline.cc
+++ b/src/jsd/el3318_offline.cc
@@ -14,7 +14,4 @@ bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node)
   return ConfigFromYamlCommon(node);
 }
 
-bool fastcat::El3318Offline::Read()
-{
-  return true;
-}
+bool fastcat::El3318Offline::Read() { return true; }

--- a/src/jsd/el3602_offline.cc
+++ b/src/jsd/el3602_offline.cc
@@ -14,7 +14,4 @@ bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node)
   return ConfigFromYamlCommon(node);
 }
 
-bool fastcat::El3602Offline::Read()
-{
-  return true;
-}
+bool fastcat::El3602Offline::Read() { return true; }

--- a/src/jsd/el4102.cc
+++ b/src/jsd/el4102.cc
@@ -58,10 +58,9 @@ fastcat::FaultType fastcat::El4102::Process()
 
 bool fastcat::El4102::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/el4102_offline.cc
+++ b/src/jsd/el4102_offline.cc
@@ -21,7 +21,7 @@ bool fastcat::El4102Offline::Write(DeviceCmd& cmd)
 {
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/ild1900.cc
+++ b/src/jsd/ild1900.cc
@@ -89,12 +89,12 @@ bool fastcat::Ild1900::Read()
   const jsd_ild1900_state_t* jsd_state =
       jsd_ild1900_get_state((jsd_t*)context_, slave_id_);
 
-  state_->ild1900_state.distance_m    = jsd_state->distance_m;
-  state_->ild1900_state.intensity     = jsd_state->intensity;
-  state_->ild1900_state.distance_raw  = jsd_state->distance_raw;
-  state_->ild1900_state.timestamp_us  = jsd_state->timestamp_us;
-  state_->ild1900_state.counter   = jsd_state->counter;
-  state_->ild1900_state.error     = jsd_state->error;
+  state_->ild1900_state.distance_m   = jsd_state->distance_m;
+  state_->ild1900_state.intensity    = jsd_state->intensity;
+  state_->ild1900_state.distance_raw = jsd_state->distance_raw;
+  state_->ild1900_state.timestamp_us = jsd_state->timestamp_us;
+  state_->ild1900_state.counter      = jsd_state->counter;
+  state_->ild1900_state.error        = jsd_state->error;
 
   return true;
 }

--- a/src/jsd/ild1900_offline.h
+++ b/src/jsd/ild1900_offline.h
@@ -17,6 +17,6 @@ class Ild1900Offline : public Ild1900
   bool Read() override;
 };
 
-}  // namespace fascat
+}  // namespace fastcat
 
 #endif

--- a/src/jsd/jed0101.cc
+++ b/src/jsd/jed0101.cc
@@ -70,16 +70,15 @@ fastcat::FaultType fastcat::Jed0101::Process()
 
 bool fastcat::Jed0101::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 
   if (cmd.type == JED0101_SET_CMD_VALUE_CMD) {
     jsd_jed0101_set_cmd_value((jsd_t*)context_, slave_id_,
-                          cmd.jed0101_set_cmd_value_cmd.cmd);
+                              cmd.jed0101_set_cmd_value_cmd.cmd);
 
   } else {
     WARNING("Bad JED0101 Command");

--- a/src/jsd/jed0101_offline.cc
+++ b/src/jsd/jed0101_offline.cc
@@ -9,15 +9,12 @@
 
 bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node)
 {
-  bool retval           = ConfigFromYamlCommon(node);
+  bool retval               = ConfigFromYamlCommon(node);
   state_->jed0101_state.cmd = initial_cmd_;
   return retval;
 }
 
-bool fastcat::Jed0101Offline::Read()
-{
-  return true;
-}
+bool fastcat::Jed0101Offline::Read() { return true; }
 
 fastcat::FaultType fastcat::Jed0101Offline::Process()
 {
@@ -26,10 +23,9 @@ fastcat::FaultType fastcat::Jed0101Offline::Process()
 
 bool fastcat::Jed0101Offline::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/jed0200.cc
+++ b/src/jsd/jed0200.cc
@@ -48,18 +48,18 @@ bool fastcat::Jed0200::Read()
   const jsd_jed0200_state_t* jsd_state =
       jsd_jed0200_get_state((jsd_t*)context_, slave_id_);
 
-  state_->jed0200_state.status = jsd_state->status;
-  state_->jed0200_state.ticks = jsd_state->ticks;
-  state_->jed0200_state.voltage_hv = jsd_state->voltage_hv;
-  state_->jed0200_state.voltage_lv = jsd_state->voltage_lv;
-  state_->jed0200_state.voltage_12v = jsd_state->voltage_12v;
-  state_->jed0200_state.temp_ambient = jsd_state->temp_ambient;
+  state_->jed0200_state.status        = jsd_state->status;
+  state_->jed0200_state.ticks         = jsd_state->ticks;
+  state_->jed0200_state.voltage_hv    = jsd_state->voltage_hv;
+  state_->jed0200_state.voltage_lv    = jsd_state->voltage_lv;
+  state_->jed0200_state.voltage_12v   = jsd_state->voltage_12v;
+  state_->jed0200_state.temp_ambient  = jsd_state->temp_ambient;
   state_->jed0200_state.temp_actuator = jsd_state->temp_actuator;
-  state_->jed0200_state.humidity = jsd_state->humidity;
-  state_->jed0200_state.pressure = jsd_state->pressure;
+  state_->jed0200_state.humidity      = jsd_state->humidity;
+  state_->jed0200_state.pressure      = jsd_state->pressure;
   state_->jed0200_state.brake_current = jsd_state->brake_current;
-  state_->jed0200_state.brake_cc_val = jsd_state->brake_cc_val;
-  state_->jed0200_state.cmd    = jsd_state->cmd;
+  state_->jed0200_state.brake_cc_val  = jsd_state->brake_cc_val;
+  state_->jed0200_state.cmd           = jsd_state->cmd;
 
   return true;
 }
@@ -72,16 +72,15 @@ fastcat::FaultType fastcat::Jed0200::Process()
 
 bool fastcat::Jed0200::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 
   if (cmd.type == JED0200_SET_CMD_VALUE_CMD) {
     jsd_jed0200_set_cmd_value((jsd_t*)context_, slave_id_,
-                          cmd.jed0200_set_cmd_value_cmd.cmd);
+                              cmd.jed0200_set_cmd_value_cmd.cmd);
 
   } else {
     WARNING("Bad JED0200 Command");

--- a/src/jsd/jed0200_offline.cc
+++ b/src/jsd/jed0200_offline.cc
@@ -9,15 +9,12 @@
 
 bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node)
 {
-  bool retval           = ConfigFromYamlCommon(node);
+  bool retval               = ConfigFromYamlCommon(node);
   state_->jed0200_state.cmd = initial_cmd_;
   return retval;
 }
 
-bool fastcat::Jed0200Offline::Read()
-{
-  return true;
-}
+bool fastcat::Jed0200Offline::Read() { return true; }
 
 fastcat::FaultType fastcat::Jed0200Offline::Process()
 {
@@ -26,10 +23,9 @@ fastcat::FaultType fastcat::Jed0200Offline::Process()
 
 bool fastcat::Jed0200Offline::Write(DeviceCmd& cmd)
 {
-
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 

--- a/src/jsd/jsd_device_base.cc
+++ b/src/jsd/jsd_device_base.cc
@@ -4,14 +4,14 @@
 // Include c then c++ libraries
 
 // Include external then project includes
-#include "jsd/jsd_sdo_pub.h"
 #include "jsd/jsd_print.h"
+#include "jsd/jsd_sdo_pub.h"
 
 bool fastcat::JsdDeviceBase::Write(DeviceCmd& cmd)
 {
   // If device supports async SDO requests
   AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
-  if(sdoResult != SDO_RET_VAL_NOT_APPLICABLE){
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
     return (sdoResult == SDO_RET_VAL_SUCCESS);
   }
 
@@ -24,13 +24,9 @@ void fastcat::JsdDeviceBase::SetSlaveId(uint16_t slave_id)
   slave_id_ = slave_id;
 }
 
-uint16_t fastcat::JsdDeviceBase::GetSlaveId() { 
-  return slave_id_; 
-}
+uint16_t fastcat::JsdDeviceBase::GetSlaveId() { return slave_id_; }
 
-void fastcat::JsdDeviceBase::SetContext(jsd_t* context) { 
-  context_ = context; 
-}
+void fastcat::JsdDeviceBase::SetContext(jsd_t* context) { context_ = context; }
 
 void fastcat::JsdDeviceBase::RegisterSdoResponseQueue(
     std::shared_ptr<std::queue<SdoResponse>> sdo_response_queue)
@@ -38,61 +34,61 @@ void fastcat::JsdDeviceBase::RegisterSdoResponseQueue(
   sdo_response_queue_ = sdo_response_queue;
 }
 
-void fastcat::JsdDeviceBase::SetOffline(bool is_offline){
+void fastcat::JsdDeviceBase::SetOffline(bool is_offline)
+{
   is_offline_ = is_offline;
-  if(is_offline){
+  if (is_offline) {
     MSG("Setting JSD device %s to offline-mode", name_.c_str());
-  }else{
+  } else {
     MSG("Setting JSD device %s to online-mode", name_.c_str());
   }
 }
 
-fastcat::JsdDeviceBase::AsyncSdoRetVal fastcat::JsdDeviceBase::WriteAsyncSdoRequest(DeviceCmd& cmd){
-  return (is_offline_) ? WriteAsyncSdoRequestOffline(cmd) : WriteAsyncSdoRequestOnline(cmd);
+fastcat::JsdDeviceBase::AsyncSdoRetVal
+fastcat::JsdDeviceBase::WriteAsyncSdoRequest(DeviceCmd& cmd)
+{
+  return (is_offline_) ? WriteAsyncSdoRequestOffline(cmd)
+                       : WriteAsyncSdoRequestOnline(cmd);
 }
 
-fastcat::JsdDeviceBase::AsyncSdoRetVal fastcat::JsdDeviceBase::WriteAsyncSdoRequestOnline(DeviceCmd& cmd){
-
+fastcat::JsdDeviceBase::AsyncSdoRetVal
+fastcat::JsdDeviceBase::WriteAsyncSdoRequestOnline(DeviceCmd& cmd)
+{
   AsyncSdoRetVal retval = SDO_RET_VAL_NOT_APPLICABLE;
 
-  if(cmd.type == ASYNC_SDO_WRITE_CMD){
-    
-    if(jsd_sdo_set_param_async(context_, slave_id_, 
-         cmd.async_sdo_write_cmd.sdo_index,
-         cmd.async_sdo_write_cmd.sdo_subindex,
-         cmd.async_sdo_write_cmd.data_type,
-         static_cast<void*>(&cmd.async_sdo_write_cmd.data),
-         cmd.async_sdo_write_cmd.app_id))
-    {
+  if (cmd.type == ASYNC_SDO_WRITE_CMD) {
+    if (jsd_sdo_set_param_async(
+            context_, slave_id_, cmd.async_sdo_write_cmd.sdo_index,
+            cmd.async_sdo_write_cmd.sdo_subindex,
+            cmd.async_sdo_write_cmd.data_type,
+            static_cast<void*>(&cmd.async_sdo_write_cmd.data),
+            cmd.async_sdo_write_cmd.app_id)) {
       retval = SDO_RET_VAL_SUCCESS;
-    }else{
+    } else {
       retval = SDO_RET_VAL_FAILURE;
     }
 
-  }else if(cmd.type == ASYNC_SDO_READ_CMD){
-
-    if(jsd_sdo_get_param_async(context_, slave_id_, 
-         cmd.async_sdo_read_cmd.sdo_index,
-         cmd.async_sdo_read_cmd.sdo_subindex,
-         cmd.async_sdo_read_cmd.data_type,
-         cmd.async_sdo_read_cmd.app_id))
-    {  
+  } else if (cmd.type == ASYNC_SDO_READ_CMD) {
+    if (jsd_sdo_get_param_async(
+            context_, slave_id_, cmd.async_sdo_read_cmd.sdo_index,
+            cmd.async_sdo_read_cmd.sdo_subindex,
+            cmd.async_sdo_read_cmd.data_type, cmd.async_sdo_read_cmd.app_id)) {
       retval = SDO_RET_VAL_SUCCESS;
-    }else{
+    } else {
       retval = SDO_RET_VAL_FAILURE;
     }
   }
   return retval;
 }
 
-fastcat::JsdDeviceBase::AsyncSdoRetVal fastcat::JsdDeviceBase::WriteAsyncSdoRequestOffline(DeviceCmd& cmd){
-
+fastcat::JsdDeviceBase::AsyncSdoRetVal
+fastcat::JsdDeviceBase::WriteAsyncSdoRequestOffline(DeviceCmd& cmd)
+{
   AsyncSdoRetVal retval = SDO_RET_VAL_NOT_APPLICABLE;
 
   SdoResponse resp;
 
-  if(cmd.type == ASYNC_SDO_WRITE_CMD){
-
+  if (cmd.type == ASYNC_SDO_WRITE_CMD) {
     resp.device_name           = cmd.name;
     resp.response.request_type = JSD_SDO_REQ_TYPE_WRITE;
     resp.response.slave_id     = slave_id_;
@@ -108,8 +104,7 @@ fastcat::JsdDeviceBase::AsyncSdoRetVal fastcat::JsdDeviceBase::WriteAsyncSdoRequ
     sdo_response_queue_->push(resp);
     retval = SDO_RET_VAL_SUCCESS;
 
-  }else if(cmd.type == ASYNC_SDO_READ_CMD){
-
+  } else if (cmd.type == ASYNC_SDO_READ_CMD) {
     resp.device_name           = cmd.name;
     resp.response.request_type = JSD_SDO_REQ_TYPE_READ;
     resp.response.slave_id     = slave_id_;

--- a/src/jsd/jsd_device_base.h
+++ b/src/jsd/jsd_device_base.h
@@ -9,46 +9,44 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-
 namespace fastcat
 {
 
-class JsdDeviceBase: public DeviceBase
+class JsdDeviceBase : public DeviceBase
 {
-
-  public:
+ public:
   typedef enum {
     SDO_RET_VAL_FAILURE,
     SDO_RET_VAL_SUCCESS,
     SDO_RET_VAL_NOT_APPLICABLE,
   } AsyncSdoRetVal;
 
-  public:
+ public:
   // overridden DeviceBase virtual methods
   bool Write(DeviceCmd& cmd) override;
-  
+
   // setters/getters for EtherCat devices
   void     SetSlaveId(uint16_t slave_id);
   uint16_t GetSlaveId();
   void     SetContext(jsd_t* context);
   void     RegisterSdoResponseQueue(
-      std::shared_ptr<std::queue<SdoResponse>> sdo_response_queue);
-  void     SetOffline(bool is_offline);
+          std::shared_ptr<std::queue<SdoResponse>> sdo_response_queue);
+  void SetOffline(bool is_offline);
 
-  protected:
+ protected:
   AsyncSdoRetVal WriteAsyncSdoRequest(DeviceCmd& cmd);
   AsyncSdoRetVal WriteAsyncSdoRequestOnline(DeviceCmd& cmd);
   AsyncSdoRetVal WriteAsyncSdoRequestOffline(DeviceCmd& cmd);
 
-  bool   is_offline_ = false; ///< If is an offline version
-  jsd_t* context_ = NULL; ///< JSD context
-  int    slave_id_ = 0;   ///< EtherCAT Slave Index
+  bool   is_offline_ = false;  ///< If is an offline version
+  jsd_t* context_    = NULL;   ///< JSD context
+  int    slave_id_   = 0;      ///< EtherCAT Slave Index
 
-  /// provided so that offline devices can push to this queue with 
+  /// provided so that offline devices can push to this queue with
   /// SDO response stubs
   std::shared_ptr<std::queue<SdoResponse>> sdo_response_queue_;
 };
 
-} // namespace fastcat
+}  // namespace fastcat
 
 #endif

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -192,8 +192,6 @@ bool fastcat::Manager::ConfigFromYaml(YAML::Node node)
   }
   SUCCESS("Configured Signals.");
 
-  this->InitializeActuatorNames();
-
   MSG("Reading initial state of all devices.");
   // Empirically observed some EGDs require at least one valid PDO write
   //   before reporting valid actual encoder positions after startup.
@@ -330,19 +328,15 @@ double fastcat::Manager::GetTargetLoopRate() { return target_loop_rate_hz_; }
 
 bool fastcat::Manager::IsFaulted() { return faulted_; }
 
-void fastcat::Manager::InitializeActuatorNames()
+void fastcat::Manager::GetDeviceNamesByType(
+    std::vector<std::string>& names, fastcat::DeviceStateType device_state_type)
 {
-  actuator_names_.clear();
+  names.clear();
   for (auto& device : jsd_device_list_) {
-    if (device->GetState()->type == ACTUATOR_STATE) {
-      actuator_names_.push_back(device->GetName());
+    if (device->GetState()->type == device_state_type) {
+      names.push_back(device->GetName());
     }
   }
-}
-
-const std::vector<std::string>& fastcat::Manager::GetActuatorNames()
-{
-  return actuator_names_;
 }
 
 bool fastcat::Manager::GetActuatorParams(

--- a/src/manager.h
+++ b/src/manager.h
@@ -172,7 +172,7 @@ class Manager
 
   /** @brief names of actuator devices
    */
-  const std::vector<std::string>& GetActuatorNames();
+ void GetDeviceNamesByType(std::vector<std::string>&, fastcat::DeviceStateType);
 
  private:
   bool ConfigJSDBusFromYaml(YAML::Node node);
@@ -185,7 +185,6 @@ class Manager
       std::vector<std::shared_ptr<DeviceBase>>& sorted_devices,
       std::vector<std::string>                  parents);
 
-  void InitializeActuatorNames();
   bool LoadActuatorPosFile();
   bool ValidateActuatorPosFile();
   bool SetActuatorPositions();
@@ -209,7 +208,6 @@ class Manager
   std::unordered_map<std::string, bool>              unique_device_map_;
   std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;
 
-  std::vector<std::string> actuator_names_;
 };
 }  // namespace fastcat
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -13,9 +13,8 @@
 #include <yaml-cpp/yaml.h>
 
 #include "fastcat/device_base.h"
-#include "fastcat/jsd/jsd_device_base.h"
 #include "fastcat/jsd/actuator.h"
-
+#include "fastcat/jsd/jsd_device_base.h"
 #include "jsd/jsd.h"
 
 namespace fastcat
@@ -23,7 +22,8 @@ namespace fastcat
 typedef std::pair<std::string, std::shared_ptr<DeviceBase>> DevicePair;
 typedef std::pair<std::string, jsd_t*>                      JSDPair;
 
-/** @brief Fastcat::Manager is the main application interface to manage all fastcat devices 
+/** @brief Fastcat::Manager is the main application interface to manage all
+ * fastcat devices
  */
 class Manager
 {
@@ -31,16 +31,17 @@ class Manager
   Manager();
   ~Manager();
 
-  /** @brief Shutdown the bus and joins all threads. 
+  /** @brief Shutdown the bus and joins all threads.
    *
-   * Also Writes Actuator positions to file if applicable. 
+   * Also Writes Actuator positions to file if applicable.
    * @return void
    */
   void Shutdown();
 
   /** @brief Method that accepts a fastcat topology yaml and intializes bus
    *
-   *  @return true on successful initialization. If false, application should quit.
+   *  @return true on successful initialization. If false, application should
+   * quit.
    */
   bool ConfigFromYaml(YAML::Node node);
 
@@ -50,38 +51,44 @@ class Manager
    *  1. Triggers PDO Read on EtherCAT bus
    *  2. Reads all JSD devices into the manager
    *  3. Reads all Fastcat devices (including observed device state propagation)
-   *  4. Calls DeviceBase::Process() on Fastcat Devices, checking for faults and SDO requests
-   *  5. Writes Device Commands (Includes User commands and Fastcat Device Commands)
+   *  4. Calls DeviceBase::Process() on Fastcat Devices, checking for faults and
+   * SDO requests
+   *  5. Writes Device Commands (Includes User commands and Fastcat Device
+   * Commands)
    *  6. Calls Process() on JSD devices, checking for faults
    *  7. Triggers PDO Write on EtherCAT bus
    *
-   *   Note: For best performance, the application should call the Manager::Process() function 
-   *     at the same frequency as the input YAML field `target_loop_rate_hz`. This parameter is
-   *     needed by certain devices for profiling and filtering.
+   *   Note: For best performance, the application should call the
+   * Manager::Process() function at the same frequency as the input YAML field
+   * `target_loop_rate_hz`. This parameter is needed by certain devices for
+   * profiling and filtering.
    *
-   *   @return Return true if bus is not faulted, otherwise a bus fault is active.
+   *   @return Return true if bus is not faulted, otherwise a bus fault is
+   * active.
    */
   bool Process();
 
   /** @brief Interface to command devices on the bus
-   *  
-   *  Commands each have a name field and that name is used to dispatch the command to 
-   *  the right device. If the provided name is not found on the loaded bus topology, a 
-   *  warning message is printed to stdout but no faults are triggered. 
+   *
+   *  Commands each have a name field and that name is used to dispatch the
+   * command to the right device. If the provided name is not found on the
+   * loaded bus topology, a warning message is printed to stdout but no faults
+   * are triggered.
    *
    *  @return void
    */
   void QueueCommand(DeviceCmd& cmd);
 
   /** @brief Returns list of device states
-   *  
+   *
    *  @return device states
    */
-  std::vector<DeviceState>                        GetDeviceStates();
+  std::vector<DeviceState> GetDeviceStates();
 
   /** @brief Returns list of device state pointers
-   *  
-   *  Provided for potential optimization. GetDeviceStates() generally performs better.
+   *
+   *  Provided for potential optimization. GetDeviceStates() generally performs
+   * better.
    *  @return device states
    */
   std::vector<std::shared_ptr<const DeviceState>> GetDeviceStatePointers();
@@ -89,52 +96,54 @@ class Manager
   /** @brief Public getter to the YAML `target_loop_rate_hz` parameter
    *  @return loop rate in hz
    */
-  double                                          GetTargetLoopRate();
+  double GetTargetLoopRate();
 
   /** @brief Public getter retrieve fault status
    *  @return true if bus is faulted
    */
-  bool                                            IsFaulted();
+  bool IsFaulted();
 
   /** @brief Attempts to recover a faulty JSD bus by name
-   * 
-   *  A bus fault example is spurious Working Counter (WKC) error, or perhaps an intended 
-   *  power cycle of a configured EtherCAT slave.
    *
-   *  @param ifname the name of the JSD bus configured in the input topology YAML
+   *  A bus fault example is spurious Working Counter (WKC) error, or perhaps an
+   * intended power cycle of a configured EtherCAT slave.
+   *
+   *  @param ifname the name of the JSD bus configured in the input topology
+   * YAML
    *  @return true if bus ifname exists, does not indicate the error is fixed.
    */
   bool RecoverBus(std::string ifname);
 
-
   /** @brief Triggers a single device to reset
-   * 
-   *  @param device_name the name of the device to reset, calls its Reset() method
+   *
+   *  @param device_name the name of the device to reset, calls its Reset()
+   * method
    *  @return true if the device exists, false if device_name is invalid.
    */
   bool ExecuteDeviceReset(std::string device_name);
 
-
   /** @brief Triggers a single device to fault
-   * 
-   *  @param device_name the name of the device to fault, calls its Fault() method
+   *
+   *  @param device_name the name of the device to fault, calls its Fault()
+   * method
    *  @return true if the device exists, false if device_name is invalid.
    */
   bool ExecuteDeviceFault(std::string device_name);
 
   /** @brief Triggers all devices to Reset
-   * 
-   *   This function loops over all devices in the topology and calls their DeviceBase::Reset()
-   *   Method. 
+   *
+   *   This function loops over all devices in the topology and calls their
+   * DeviceBase::Reset() Method.
    *
    *   @return void
    */
   void ExecuteAllDeviceResets();
 
   /** @brief Triggers all devices to Fault
-   * 
-   *   This function loops over all devices in the topology and calls their DeviceBase::Fault()
-   *   Method. An example usage is a soft-stop GUI button that can be used to arrest motion.
+   *
+   *   This function loops over all devices in the topology and calls their
+   * DeviceBase::Fault() Method. An example usage is a soft-stop GUI button that
+   * can be used to arrest motion.
    *
    *   @return void
    */
@@ -145,23 +154,23 @@ class Manager
    */
   bool IsSdoResponseQueueEmpty();
 
-  /** @brief get the result of a background SDO operation 
+  /** @brief get the result of a background SDO operation
    *
-   *  If the SDO Response queue contains any responses, this function pops the 
+   *  If the SDO Response queue contains any responses, this function pops the
    *  oldest value and returns it to the application.
    *
    *  @return true if the return reference 'res' is valid
    */
   bool PopSdoResponseQueue(SdoResponse& res);
 
-  /** @brief get actuator parameters 
+  /** @brief get actuator parameters
    *
    *  @return true if the return reference 'parameters' is valid
    */
-  bool GetActuatorParams(
-    const std::string& name, fastcat::Actuator::ActuatorParams& param);
+  bool GetActuatorParams(const std::string&                 name,
+                         fastcat::Actuator::ActuatorParams& param);
 
-  /** @brief names of actuator devices 
+  /** @brief names of actuator devices
    */
   const std::vector<std::string>& GetActuatorNames();
 
@@ -199,7 +208,7 @@ class Manager
   std::map<std::string, ActuatorPosData>             actuator_pos_map_;
   std::unordered_map<std::string, bool>              unique_device_map_;
   std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;
-  
+
   std::vector<std::string> actuator_names_;
 };
 }  // namespace fastcat

--- a/src/manager.h
+++ b/src/manager.h
@@ -14,6 +14,7 @@
 
 #include "fastcat/device_base.h"
 #include "fastcat/jsd/jsd_device_base.h"
+#include "fastcat/jsd/actuator.h"
 
 #include "jsd/jsd.h"
 
@@ -153,6 +154,16 @@ class Manager
    */
   bool PopSdoResponseQueue(SdoResponse& res);
 
+  /** @brief get actuator parameters 
+   *
+   *  @return true if the return reference 'parameters' is valid
+   */
+  bool GetActuatorParams(
+    const std::string& name, fastcat::Actuator::ActuatorParams& param);
+
+  /** @brief names of actuator devices 
+   */
+  const std::vector<std::string>& GetActuatorNames();
 
  private:
   bool ConfigJSDBusFromYaml(YAML::Node node);
@@ -165,6 +176,7 @@ class Manager
       std::vector<std::shared_ptr<DeviceBase>>& sorted_devices,
       std::vector<std::string>                  parents);
 
+  void InitializeActuatorNames();
   bool LoadActuatorPosFile();
   bool ValidateActuatorPosFile();
   bool SetActuatorPositions();
@@ -187,6 +199,8 @@ class Manager
   std::map<std::string, ActuatorPosData>             actuator_pos_map_;
   std::unordered_map<std::string, bool>              unique_device_map_;
   std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;
+  
+  std::vector<std::string> actuator_names_;
 };
 }  // namespace fastcat
 

--- a/test/test_cli.cc
+++ b/test/test_cli.cc
@@ -8,10 +8,10 @@
 #include "fastcat/fastcat.h"
 #include "jsd/jsd_timer.h"
 
-pthread_mutex_t   fastcat_mutex = PTHREAD_MUTEX_INITIALIZER;
-fastcat::Manager  manager;
-double            cli_start_time;
-FILE*             file;
+pthread_mutex_t  fastcat_mutex = PTHREAD_MUTEX_INITIALIZER;
+fastcat::Manager manager;
+double           cli_start_time;
+FILE*            file;
 
 void print_header(std::vector<fastcat::DeviceState> states)
 {
@@ -128,7 +128,7 @@ void print_header(std::vector<fastcat::DeviceState> states)
         fprintf(file, "%s_egd_actual_position, ", state->name.c_str());
         fprintf(file, "%s_egd_cmd_position, ", state->name.c_str());
 
-        fprintf(file, "%s_motor_on, ",  state->name.c_str());
+        fprintf(file, "%s_motor_on, ", state->name.c_str());
         fprintf(file, "%s_servo_enabled, ", state->name.c_str());
         break;
       case fastcat::LINEAR_INTERPOLATION_STATE:
@@ -377,17 +377,16 @@ void* cli_process(void*)
     } else if (tokens[0].compare("jed0101_set_cmd_value") == 0 &&
                tokens.size() == 3) {
       MSG("Issuing jed0101_set_cmd_value command");
-      cmd.name                      = tokens[1];
+      cmd.name                          = tokens[1];
       cmd.jed0101_set_cmd_value_cmd.cmd = atoi(tokens[2].c_str());
-      cmd.type                      = fastcat::JED0101_SET_CMD_VALUE_CMD;
-
+      cmd.type                          = fastcat::JED0101_SET_CMD_VALUE_CMD;
 
     } else if (tokens[0].compare("jed0200_set_cmd_value") == 0 &&
                tokens.size() == 3) {
       MSG("Issuing jed0200_set_cmd_value command");
-      cmd.name                      = tokens[1];
+      cmd.name                          = tokens[1];
       cmd.jed0200_set_cmd_value_cmd.cmd = atoi(tokens[2].c_str());
-      cmd.type                      = fastcat::JED0200_SET_CMD_VALUE_CMD;
+      cmd.type                          = fastcat::JED0200_SET_CMD_VALUE_CMD;
 
     } else if (tokens[0].compare("actuator_set_output_position") == 0 &&
                tokens.size() == 3) {

--- a/test/test_unit/test_actuator.cc
+++ b/test/test_unit/test_actuator.cc
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
+
 #include <cmath>
 
 #include "fastcat/config.h"
 #include "fastcat/jsd/actuator_offline.h"
 #include "fastcat/signal_handling.h"
-
 #include "jsd/jsd_print.h"
 
 namespace
@@ -25,136 +25,135 @@ class ActuatorTest : public ::testing::Test
     device_.SetOffline(true);
   }
 
-  void TearDown() override
-  {
-    jsd_free(jsd_context_);
-  }
+  void TearDown() override { jsd_free(jsd_context_); }
 
-  jsd_t* jsd_context_;
-  std::string base_dir_;
-  YAML::Node node_;
+  jsd_t*                   jsd_context_;
+  std::string              base_dir_;
+  YAML::Node               node_;
   fastcat::ActuatorOffline device_;
 };
 
-  TEST_F(ActuatorTest, ParseValidWithPower) {
-    EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid_with_power.yaml")));
+TEST_F(ActuatorTest, ParseValidWithPower)
+{
+  EXPECT_TRUE(device_.ConfigFromYaml(
+      YAML::LoadFile(base_dir_ + "valid_with_power.yaml")));
+}
+
+TEST_F(ActuatorTest, ParseValidWithOptional)
+{
+  EXPECT_TRUE(device_.ConfigFromYaml(
+      YAML::LoadFile(base_dir_ + "valid_with_opts.yaml")));
+}
+
+TEST_F(ActuatorTest, ParseValid)
+{
+  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "valid.yaml")));
+}
+
+TEST_F(ActuatorTest, RejectMotionCommandsWhenFaulted)
+{
+  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "valid.yaml")));
+
+  device_.Fault();
+
+  // Fail Motion commands
+  {  // CSP
+    fastcat::DeviceCmd cmd;
+    cmd.type                                = fastcat::ACTUATOR_CSP_CMD;
+    cmd.actuator_csp_cmd.target_position    = 0;
+    cmd.actuator_csp_cmd.position_offset    = 0;
+    cmd.actuator_csp_cmd.velocity_offset    = 0;
+    cmd.actuator_csp_cmd.torque_offset_amps = 0;
+    EXPECT_FALSE(device_.Write(cmd));
   }
-  
-  TEST_F(ActuatorTest, ParseValidWithOptional) {
-    EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid_with_opts.yaml")));
+  {  // CSV
+    fastcat::DeviceCmd cmd;
+    cmd.type                                = fastcat::ACTUATOR_CSV_CMD;
+    cmd.actuator_csv_cmd.target_velocity    = 0;
+    cmd.actuator_csv_cmd.velocity_offset    = 0;
+    cmd.actuator_csv_cmd.torque_offset_amps = 0;
+    EXPECT_FALSE(device_.Write(cmd));
   }
-  
-  TEST_F(ActuatorTest, ParseValid) {
-    EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid.yaml")));
+  {  // CST
+    fastcat::DeviceCmd cmd;
+    cmd.type                                = fastcat::ACTUATOR_CST_CMD;
+    cmd.actuator_cst_cmd.target_torque_amps = 0;
+    cmd.actuator_cst_cmd.torque_offset_amps = 0;
+    EXPECT_FALSE(device_.Write(cmd));
   }
+  {  // Prof Pos
+    fastcat::DeviceCmd cmd;
+    cmd.type                                   = fastcat::ACTUATOR_PROF_POS_CMD;
+    cmd.actuator_prof_pos_cmd.target_position  = 0;
+    cmd.actuator_prof_pos_cmd.profile_velocity = 0.1;
+    cmd.actuator_prof_pos_cmd.end_velocity     = 0;
+    cmd.actuator_prof_pos_cmd.profile_accel    = 0.1;
+    cmd.actuator_prof_pos_cmd.relative         = 0;
+    EXPECT_FALSE(device_.Write(cmd));
+  }
+  {  // Prof Vel
+    fastcat::DeviceCmd cmd;
+    cmd.type                                  = fastcat::ACTUATOR_PROF_VEL_CMD;
+    cmd.actuator_prof_vel_cmd.target_velocity = 0.1;
+    cmd.actuator_prof_vel_cmd.profile_accel   = 0.1;
+    cmd.actuator_prof_vel_cmd.max_duration    = 30;
+    EXPECT_FALSE(device_.Write(cmd));
+  }
+  {  // Prof Torque
+    fastcat::DeviceCmd cmd;
+    cmd.type = fastcat::ACTUATOR_PROF_TORQUE_CMD;
+    cmd.actuator_prof_torque_cmd.target_torque_amps = 0;
+    cmd.actuator_prof_torque_cmd.max_duration       = 30;
+    EXPECT_FALSE(device_.Write(cmd));
+  }
+  {  // Calibrate
+    fastcat::DeviceCmd cmd;
+    cmd.type                               = fastcat::ACTUATOR_CALIBRATE_CMD;
+    cmd.actuator_calibrate_cmd.velocity    = 0.02;
+    cmd.actuator_calibrate_cmd.accel       = 0.2;
+    cmd.actuator_calibrate_cmd.max_current = 0.2;
+    EXPECT_FALSE(device_.Write(cmd));
+  }
+  {  // Halt
+    fastcat::DeviceCmd cmd;
 
-  TEST_F(ActuatorTest, RejectMotionCommandsWhenFaulted) {
-    EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid.yaml")));
-
-    device_.Fault();
-
-    // Fail Motion commands
-    { // CSP
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_CSP_CMD;
-      cmd.actuator_csp_cmd.target_position    = 0;
-      cmd.actuator_csp_cmd.position_offset    = 0;
-      cmd.actuator_csp_cmd.velocity_offset    = 0;
-      cmd.actuator_csp_cmd.torque_offset_amps = 0;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // CSV
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_CSV_CMD;
-      cmd.actuator_csv_cmd.target_velocity    = 0;
-      cmd.actuator_csv_cmd.velocity_offset    = 0;
-      cmd.actuator_csv_cmd.torque_offset_amps = 0;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // CST
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_CST_CMD;
-      cmd.actuator_cst_cmd.target_torque_amps = 0;
-      cmd.actuator_cst_cmd.torque_offset_amps = 0;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // Prof Pos
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_PROF_POS_CMD;
-      cmd.actuator_prof_pos_cmd.target_position  = 0;
-      cmd.actuator_prof_pos_cmd.profile_velocity = 0.1;
-      cmd.actuator_prof_pos_cmd.end_velocity     = 0;
-      cmd.actuator_prof_pos_cmd.profile_accel    = 0.1;
-      cmd.actuator_prof_pos_cmd.relative         = 0;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // Prof Vel
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_PROF_VEL_CMD;
-      cmd.actuator_prof_vel_cmd.target_velocity  = 0.1;
-      cmd.actuator_prof_vel_cmd.profile_accel    = 0.1;
-      cmd.actuator_prof_vel_cmd.max_duration     = 30;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // Prof Torque
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_PROF_TORQUE_CMD;
-      cmd.actuator_prof_torque_cmd.target_torque_amps = 0;
-      cmd.actuator_prof_torque_cmd.max_duration       = 30;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // Calibrate
-      fastcat::DeviceCmd cmd;
-      cmd.type = fastcat::ACTUATOR_CALIBRATE_CMD;
-      cmd.actuator_calibrate_cmd.velocity    = 0.02;
-      cmd.actuator_calibrate_cmd.accel       = 0.2;
-      cmd.actuator_calibrate_cmd.max_current = 0.2;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-    { // Halt
-      fastcat::DeviceCmd cmd;
-
-      cmd.type = fastcat::ACTUATOR_HALT_CMD;
-      EXPECT_FALSE(device_.Write(cmd));
-    }
-
-    { // Confirm non-motion commands are still accepted
-      fastcat::DeviceCmd cmd;
-
-      cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SET_OUTPUT_POSITION_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SET_MAX_CURRENT_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SDO_SET_UNIT_MODE_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SDO_SET_UNIT_MODE_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SDO_DISABLE_GAIN_SCHEDULING_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-
-      cmd.type = fastcat::ACTUATOR_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD;
-      EXPECT_TRUE(device_.Write(cmd));
-    }
-
-
+    cmd.type = fastcat::ACTUATOR_HALT_CMD;
+    EXPECT_FALSE(device_.Write(cmd));
   }
 
+  {  // Confirm non-motion commands are still accepted
+    fastcat::DeviceCmd cmd;
 
+    cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
 
-} // namespace
+    cmd.type = fastcat::ACTUATOR_SET_GAIN_SCHEDULING_INDEX_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SET_OUTPUT_POSITION_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SET_MAX_CURRENT_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SDO_SET_UNIT_MODE_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SDO_SET_UNIT_MODE_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SDO_DISABLE_GAIN_SCHEDULING_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SDO_ENABLE_SPEED_GAIN_SCHEDULING_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SDO_ENABLE_POSITION_GAIN_SCHEDULING_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+
+    cmd.type = fastcat::ACTUATOR_SDO_ENABLE_MANUAL_GAIN_SCHEDULING_CMD;
+    EXPECT_TRUE(device_.Write(cmd));
+  }
+}
+
+}  // namespace

--- a/test/test_unit/test_ati_fts.cc
+++ b/test/test_unit/test_ati_fts.cc
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
+
 #include <cmath>
 
 #include "fastcat/config.h"
 #include "fastcat/jsd/ati_fts.h"
 #include "fastcat/signal_handling.h"
-
 #include "jsd/jsd.h"
 #include "jsd/jsd_print.h"
 
@@ -26,25 +26,26 @@ class AtiFtsTest : public ::testing::Test
     device_.SetOffline(true);
   }
 
-  void TearDown() override
-  {
-    jsd_free(jsd_context_);
-  }
+  void TearDown() override { jsd_free(jsd_context_); }
 
-  jsd_t* jsd_context_;
-  std::string base_dir_;
-  YAML::Node node_;
+  jsd_t*          jsd_context_;
+  std::string     base_dir_;
+  YAML::Node      node_;
   fastcat::AtiFts device_;
 };
 
-TEST_F(AtiFtsTest, ParseNominalConfig) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"nominal.yaml")));
+TEST_F(AtiFtsTest, ParseNominalConfig)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "nominal.yaml")));
 }
 
 // Currently the nominal behavior to faults is to prevent taring when faulted
 // This may change with optional YAML parameters in the future perhaps.
-TEST_F(AtiFtsTest, RejectTareWhenFaulted) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"nominal.yaml")));
+TEST_F(AtiFtsTest, RejectTareWhenFaulted)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "nominal.yaml")));
 
   fastcat::DeviceCmd cmd;
   cmd.type = fastcat::FTS_TARE_CMD;
@@ -57,4 +58,4 @@ TEST_F(AtiFtsTest, RejectTareWhenFaulted) {
   EXPECT_FALSE(device_.Write(cmd));
 }
 
-} // namespace
+}  // namespace

--- a/test/test_unit/test_commander.cc
+++ b/test/test_unit/test_commander.cc
@@ -93,7 +93,7 @@ TEST_F(CommanderTest, CmdsRejectedWhenFaulted)
   EXPECT_FALSE(c2_.GetState()->commander_state.enable);
 
   // Reject Enable
-  cmd.type = fastcat::COMMANDER_ENABLE_CMD;
+  cmd.type                          = fastcat::COMMANDER_ENABLE_CMD;
   cmd.commander_enable_cmd.duration = 30;
 
   EXPECT_FALSE(c2_.Write(cmd));
@@ -103,9 +103,6 @@ TEST_F(CommanderTest, CmdsRejectedWhenFaulted)
   c2_.Reset();
   EXPECT_TRUE(c2_.Write(cmd));
   EXPECT_TRUE(c2_.GetState()->commander_state.enable);
-
-
 }
-
 
 }  // namespace

--- a/test/test_unit/test_fts.cc
+++ b/test/test_unit/test_fts.cc
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
+
 #include <cmath>
 
 #include "fastcat/config.h"
 #include "fastcat/fastcat_devices/fts.h"
 #include "fastcat/signal_handling.h"
-
 #include "jsd/jsd_print.h"
 
 class FtsTest : public ::testing::Test
@@ -17,19 +17,23 @@ class FtsTest : public ::testing::Test
     base_dir_ += "test_fts_yamls/";
   }
 
-  std::string base_dir_;
-  YAML::Node node_;
+  std::string  base_dir_;
+  YAML::Node   node_;
   fastcat::Fts device_;
 };
 
-TEST_F(FtsTest, ParseNominalConfig) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"nominal.yaml")));
+TEST_F(FtsTest, ParseNominalConfig)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "nominal.yaml")));
 }
 
 // Currently the nominal behavior to faults is to prevent taring when faulted
 // This may change with optional YAML parameters in the future perhaps.
-TEST_F(FtsTest, RejectTareWhenFaulted) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"nominal.yaml")));
+TEST_F(FtsTest, RejectTareWhenFaulted)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "nominal.yaml")));
 
   fastcat::DeviceCmd cmd;
   cmd.type = fastcat::FTS_TARE_CMD;

--- a/test/test_unit/test_jsd_device_base.cc
+++ b/test/test_unit/test_jsd_device_base.cc
@@ -1,26 +1,27 @@
 #include <gtest/gtest.h>
 
 #include "fastcat/config.h"
-#include "fastcat/jsd/jsd_device_base.h"
 #include "fastcat/jsd/actuator_offline.h"
+#include "fastcat/jsd/jsd_device_base.h"
 
 namespace
 {
 class JsdDeviceBaseTest : public ::testing::Test
 {
  protected:
-  void SetUp() override {
+  void SetUp() override
+  {
     // FASTCAT_UNIT_TEST_DIR contains path to .
     sdo_response_queue_ = std::make_shared<std::queue<fastcat::SdoResponse>>();
     device_.SetOffline(true);
   }
 
-  fastcat::ActuatorOffline device_;
+  fastcat::ActuatorOffline                          device_;
   std::shared_ptr<std::queue<fastcat::SdoResponse>> sdo_response_queue_;
 };
 
-TEST_F(JsdDeviceBaseTest, TesterQueueOps){
-
+TEST_F(JsdDeviceBaseTest, TesterQueueOps)
+{
   EXPECT_TRUE(sdo_response_queue_->empty());
 
   {
@@ -30,19 +31,17 @@ TEST_F(JsdDeviceBaseTest, TesterQueueOps){
     EXPECT_FALSE(sdo_response_queue_->empty());
   }
 
-
   {
     fastcat::SdoResponse resp;
     resp = sdo_response_queue_->front();
     sdo_response_queue_->pop();
-    EXPECT_EQ(0,resp.device_name.compare("jose_cuervo"));
+    EXPECT_EQ(0, resp.device_name.compare("jose_cuervo"));
     EXPECT_TRUE(sdo_response_queue_->empty());
   }
 }
 
-
-TEST_F(JsdDeviceBaseTest, RegisterAndUseSdo){
-
+TEST_F(JsdDeviceBaseTest, RegisterAndUseSdo)
+{
   device_.RegisterSdoResponseQueue(sdo_response_queue_);
 
   fastcat::DeviceCmd cmd;
@@ -66,13 +65,13 @@ TEST_F(JsdDeviceBaseTest, RegisterAndUseSdo){
     sdo_response_queue_->pop();
 
     EXPECT_EQ(0, resp.device_name.compare("patron"));
-    EXPECT_EQ(resp.response.sdo_index,    0xDEAD);
+    EXPECT_EQ(resp.response.sdo_index, 0xDEAD);
     EXPECT_EQ(resp.response.sdo_subindex, 3);
-    EXPECT_EQ(resp.response.data.as_u16,  0xBEEF);
-    EXPECT_EQ(resp.response.app_id,       123);
+    EXPECT_EQ(resp.response.data.as_u16, 0xBEEF);
+    EXPECT_EQ(resp.response.app_id, 123);
 
     EXPECT_TRUE(resp.response.success);
   }
 }
 
-} //namespace
+}  // namespace

--- a/test/test_unit/test_linear_interpolation.cc
+++ b/test/test_unit/test_linear_interpolation.cc
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
+
 #include <cmath>
 
 #include "fastcat/config.h"
 #include "fastcat/fastcat_devices/linear_interpolation.h"
 #include "fastcat/signal_handling.h"
-
 #include "jsd/jsd_print.h"
 
 namespace
@@ -18,91 +18,107 @@ class LinearInterpolationTest : public ::testing::Test
     base_dir_ += "test_linear_interpolation_yamls/";
   }
 
-  std::string base_dir_;
-  YAML::Node node_;
+  std::string                  base_dir_;
+  YAML::Node                   node_;
   fastcat::LinearInterpolation device_;
 };
 
-TEST_F(LinearInterpolationTest, InvalidNoName) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_1.yaml")));
+TEST_F(LinearInterpolationTest, InvalidNoName)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_1.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, InvalidNoOutOfBoundsFlag) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_2.yaml")));
+TEST_F(LinearInterpolationTest, InvalidNoOutOfBoundsFlag)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_2.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, InvalidSizeMismatch) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_3.yaml")));
+TEST_F(LinearInterpolationTest, InvalidSizeMismatch)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_3.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, InvalidTableTooSmall) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_4.yaml")));
+TEST_F(LinearInterpolationTest, InvalidTableTooSmall)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_4.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, InvalidRepeated) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_5.yaml")));
+TEST_F(LinearInterpolationTest, InvalidRepeated)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_5.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, InvalidManySignals) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_6.yaml")));
+TEST_F(LinearInterpolationTest, InvalidManySignals)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_6.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, InvalidNoSignals) {
-  EXPECT_FALSE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"invalid_7.yaml")));
+TEST_F(LinearInterpolationTest, InvalidNoSignals)
+{
+  EXPECT_FALSE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "invalid_7.yaml")));
 }
 
-TEST_F(LinearInterpolationTest, ValidAbs) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid_abs.yaml")));
-  // This table is valid from -30 to +20 and should be a perfect fabs function 
+TEST_F(LinearInterpolationTest, ValidAbs)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "valid_abs.yaml")));
+  // This table is valid from -30 to +20 and should be a perfect fabs function
   // in this range.
 
-  auto state = device_.GetState();
-  double *output = &state->linear_interpolation_state.output;
-  double *input = &device_.signals_[0].value;
+  auto    state  = device_.GetState();
+  double* output = &state->linear_interpolation_state.output;
+  double* input  = &device_.signals_[0].value;
 
   *input = -100;
-  EXPECT_FALSE(device_.Read()); // off the interp table
+  EXPECT_FALSE(device_.Read());  // off the interp table
   EXPECT_NEAR(*output, 30, 1e-12);
   device_.Reset();
 
   *input = 100;
-  EXPECT_FALSE(device_.Read()); // off the interp table
+  EXPECT_FALSE(device_.Read());  // off the interp table
   EXPECT_NEAR(*output, 20, 1e-12);
   device_.Reset();
 
-
   // Test nominal ranges
   double step = 1.5;
-  *input = -15;
-  while(*input < 15){
+  *input      = -15;
+  while (*input < 15) {
     *input += step;
-    EXPECT_TRUE(device_.Read()); 
+    EXPECT_TRUE(device_.Read());
     EXPECT_NEAR(*output, fabs(*input), 1e-12);
     MSG("testing fabs(%lf) = %lf ", *input, *output);
   }
 
   // finer-grained
-  step = 0.001;
+  step   = 0.001;
   *input = -30;
-  while(*input < (20 - step)){
+  while (*input < (20 - step)) {
     *input += step;
-    EXPECT_TRUE(device_.Read()); 
+    EXPECT_TRUE(device_.Read());
     EXPECT_NEAR(*output, fabs(*input), 1e-12);
   }
 }
 
-
-TEST_F(LinearInterpolationTest, ValidAbsDecadeTests) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid_abs_no_error.yaml")));
-  // This table is valid from -30 to +20 and should be a perfect fabs function 
+TEST_F(LinearInterpolationTest, ValidAbsDecadeTests)
+{
+  EXPECT_TRUE(device_.ConfigFromYaml(
+      YAML::LoadFile(base_dir_ + "valid_abs_no_error.yaml")));
+  // This table is valid from -30 to +20 and should be a perfect fabs function
   // in this range.
 
-  auto state = device_.GetState();
-  double *output = &state->linear_interpolation_state.output;
-  double *input = &device_.signals_[0].value;
+  auto    state  = device_.GetState();
+  double* output = &state->linear_interpolation_state.output;
+  double* input  = &device_.signals_[0].value;
 
   // the val here increases logarithimically like so:
-  //      v--- start here since (i=-4) 
+  //      v--- start here since (i=-4)
   // 0.0001
   // 0.0002
   // ...
@@ -112,41 +128,40 @@ TEST_F(LinearInterpolationTest, ValidAbsDecadeTests) {
   // ...
   // 0.0090
   // 0.0100
-  for(int i = -6; i < 0; i++){
+  for (int i = -6; i < 0; i++) {
     double decade = pow(10, i);
-    for(int j = 1; j < 10; j++){
+    for (int j = 1; j < 10; j++) {
       double val = (double)j * decade;
       MSG_DEBUG("val: %0.6lf", val);
 
       // off table, low-end
       *input = -30 - val;
-      EXPECT_TRUE(device_.Read()); 
+      EXPECT_TRUE(device_.Read());
       EXPECT_NEAR(*output, 30, 1e-12);
 
       *input = -30 + val;
-      EXPECT_TRUE(device_.Read()); 
+      EXPECT_TRUE(device_.Read());
       EXPECT_NEAR(*output, fabs(*input), 1e-12);
 
       // At the zero pivot
       *input = 0 - val;
-      EXPECT_TRUE(device_.Read()); 
+      EXPECT_TRUE(device_.Read());
       EXPECT_NEAR(*output, fabs(*input), 1e-12);
 
       *input = 0 + val;
-      EXPECT_TRUE(device_.Read()); 
+      EXPECT_TRUE(device_.Read());
       EXPECT_NEAR(*output, fabs(*input), 1e-12);
 
       // off table, high-end
       *input = 20 + val;
-      EXPECT_TRUE(device_.Read()); 
+      EXPECT_TRUE(device_.Read());
       EXPECT_NEAR(*output, 20, 1e-12);
 
       *input = 20 - val;
-      EXPECT_TRUE(device_.Read()); 
+      EXPECT_TRUE(device_.Read());
       EXPECT_NEAR(*output, fabs(*input), 1e-12);
     }
   }
-
 }
 
 }  // namespace

--- a/test/test_unit/test_trap.cc
+++ b/test/test_unit/test_trap.cc
@@ -7,51 +7,41 @@ namespace
 class TrapTest : public ::testing::Test
 {
  protected:
-  void SetUp() override {
-  }
+  void SetUp() override {}
 
   trap_t trap_1_;
 };
 
-TEST_F(TrapTest, TrapVelocityReInit){
-
-  double time_initial = 0.0;
+TEST_F(TrapTest, TrapVelocityReInit)
+{
+  double time_initial     = 0.0;
   double position_initial = 0.0;
   double velocity_initial = 0.0;
-  double velocity_final = 1.0;
-  double acceleration = 1.0;
-  double max_time = 10.0;
+  double velocity_final   = 1.0;
+  double acceleration     = 1.0;
+  double max_time         = 10.0;
 
   // Generate the first version of the trap
-  trap_generate_vel(&trap_1_,
-                    time_initial,
-                    position_initial,
-                    velocity_initial,
-                    velocity_final,
-                    acceleration,
-                    max_time);
+  trap_generate_vel(&trap_1_, time_initial, position_initial, velocity_initial,
+                    velocity_final, acceleration, max_time);
 
   double dt = 0.01;
-  
-  double tracking_time = time_initial;
+
+  double tracking_time     = time_initial;
   double tracking_position = position_initial;
   double tracking_velocity = velocity_initial;
 
-  for (int i=0; i<1000; i++) {
+  for (int i = 0; i < 1000; i++) {
     // Update trap before any change in time has occurred
-    trap_update_vel(&trap_1_, tracking_time,
-                    &tracking_position,
+    trap_update_vel(&trap_1_, tracking_time, &tracking_position,
                     &tracking_velocity);
 
     // Increment time
     tracking_time += dt;
-    
+
     // Regenerate trap to simulate incoming updated setpoint
-    trap_generate_vel(&trap_1_, tracking_time,
-                      tracking_position,
-                      tracking_velocity,
-                      velocity_final,
-                      acceleration,
+    trap_generate_vel(&trap_1_, tracking_time, tracking_position,
+                      tracking_velocity, velocity_final, acceleration,
                       max_time);
   }
 
@@ -60,4 +50,4 @@ TEST_F(TrapTest, TrapVelocityReInit){
   EXPECT_TRUE(tracking_position > position_initial);
 }
 
-}
+}  // namespace

--- a/test/test_unit/test_virtual_fts.cc
+++ b/test/test_unit/test_virtual_fts.cc
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
+
 #include <cmath>
 
 #include "fastcat/config.h"
 #include "fastcat/fastcat_devices/virtual_fts.h"
 #include "fastcat/signal_handling.h"
-
 #include "jsd/jsd_print.h"
 
 class VirtualFtsTest : public ::testing::Test
@@ -17,19 +17,23 @@ class VirtualFtsTest : public ::testing::Test
     base_dir_ += "test_virtual_fts_yamls/";
   }
 
-  std::string base_dir_;
-  YAML::Node node_;
+  std::string         base_dir_;
+  YAML::Node          node_;
   fastcat::VirtualFts device_;
 };
 
-TEST_F(VirtualFtsTest, ParseNominalConfig) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"nominal.yaml")));
+TEST_F(VirtualFtsTest, ParseNominalConfig)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "nominal.yaml")));
 }
 
 // Currently the nominal behavior to faults is to prevent taring when faulted
 // This may change with optional YAML parameters in the future perhaps.
-TEST_F(VirtualFtsTest, RejectTareWhenFaulted) {
-  EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"nominal.yaml")));
+TEST_F(VirtualFtsTest, RejectTareWhenFaulted)
+{
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "nominal.yaml")));
 
   fastcat::DeviceCmd cmd;
   cmd.type = fastcat::FTS_TARE_CMD;


### PR DESCRIPTION
Alternative implementation of https://github.com/nasa-jpl/fastcat/pull/64

* Moves actuator parameters into a struct within the Actuator class, which allows easily exposing other actuator parameters to the application without having to add additional getter/setter methods

* Allows querying list of actuator devices as:
```C++
const std::vector<std::string>& actuator_names = fastcat_manager_->GetActuatorNames();
```

* Once you know your actuator names, you can query the parameters as:
```C++
for(auto& name : actuator_names) {
  fastcat::Actuator::ActuatorParams params;
  bool success = fastcat_manager_->GetActuatorParams(name, params);
  if(success) {
    // do something with the params
  }
```

I didn't read @alex-brinkman's comment in the other linked PR until after I had already written the code; I arrived independently on a solution very similar to Alex's second suggestion.