### PR TITLE
Apb ut visibility declarations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,10 +57,7 @@ add_custom_target(fcgen
     ${CMAKE_BINARY_DIR}/fastcat/autogen/fastcat_devices/commander.cc
     )
 
-# Build a library regardless of BUILD_TESTS flag
-set(FASTCAT_SOURCES
-)
-
+# This Macro is reused to create a test library as well when necessary
 macro(create_fastcat_lib)
   message("creating library: ${ARGV0}")
   add_library(${ARGV0} STATIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,6 @@ target_compile_definitions(fastcat PUBLIC PROTECTED=protected PRIVATE=private)
 
 if(BUILD_TESTS)
     create_fastcat_lib(fastcat-test)
-    message("fastcat-test: Overriding protected and private class methods for internal unit testing"
+    message("fastcat-test: Overriding protected and private class methods for internal unit testing")
     target_compile_definitions(fastcat-test PUBLIC PROTECTED=public PRIVATE=public)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,64 +59,63 @@ add_custom_target(fcgen
 
 # Build a library regardless of BUILD_TESTS flag
 set(FASTCAT_SOURCES
-    trap.c
-    device_base.cc
-    manager.cc
-    yaml_parser.cc
-    ${CMAKE_BINARY_DIR}/fastcat/autogen/signal_handling.cc
-    transform_utils.cc
-
-    jsd/jsd_device_base.cc
-
-    jsd/actuator.cc
-    jsd/actuator_fsm_helpers.cc
-    jsd/egd.cc
-    jsd/el3208.cc
-    jsd/el3602.cc
-    jsd/el2124.cc
-    jsd/el4102.cc
-    jsd/el3162.cc
-    jsd/el3104.cc
-    jsd/el3202.cc
-    jsd/el3318.cc
-    jsd/ild1900.cc
-    jsd/jed0101.cc
-    jsd/jed0200.cc
-    jsd/ati_fts.cc
-
-    jsd/actuator_offline.cc
-    jsd/egd_offline.cc
-    jsd/el2124_offline.cc
-    jsd/el4102_offline.cc
-    jsd/el3208_offline.cc
-    jsd/el3602_offline.cc
-    jsd/el3162_offline.cc
-    jsd/el3104_offline.cc
-    jsd/el3202_offline.cc
-    jsd/el3318_offline.cc
-    jsd/ild1900_offline.cc
-    jsd/jed0101_offline.cc
-    jsd/jed0200_offline.cc
-    jsd/ati_fts_offline.cc
-
-    ${CMAKE_BINARY_DIR}/fastcat/autogen/fastcat_devices/commander.cc
-    fastcat_devices/signal_generator.cc
-    fastcat_devices/function.cc
-    fastcat_devices/conditional.cc
-    fastcat_devices/pid.cc
-    fastcat_devices/saturation.cc
-    fastcat_devices/schmitt_trigger.cc
-    fastcat_devices/filter.cc
-    fastcat_devices/fts.cc
-    fastcat_devices/virtual_fts.cc
-    fastcat_devices/faulter.cc
-    fastcat_devices/linear_interpolation.cc
 )
 
 macro(create_fastcat_lib)
   message("creating library: ${ARGV0}")
   add_library(${ARGV0} STATIC
-     ${FASTCAT_SOURCES}
+      ${PROJECT_SOURCE_DIR}/src/trap.c
+      ${PROJECT_SOURCE_DIR}/src/device_base.cc
+      ${PROJECT_SOURCE_DIR}/src/manager.cc
+      ${PROJECT_SOURCE_DIR}/src/yaml_parser.cc
+      ${CMAKE_BINARY_DIR}/fastcat/autogen/signal_handling.cc
+      ${PROJECT_SOURCE_DIR}/src/transform_utils.cc
+
+      ${PROJECT_SOURCE_DIR}/src/jsd/jsd_device_base.cc
+
+      ${PROJECT_SOURCE_DIR}/src/jsd/actuator.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/actuator_fsm_helpers.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/egd.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3208.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3602.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el2124.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el4102.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3162.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3104.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3202.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3318.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/ild1900.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/jed0101.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/jed0200.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/ati_fts.cc
+
+      ${PROJECT_SOURCE_DIR}/src/jsd/actuator_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/egd_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el2124_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el4102_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3208_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3602_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3162_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3104_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3202_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/el3318_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/ild1900_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/jed0101_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/jed0200_offline.cc
+      ${PROJECT_SOURCE_DIR}/src/jsd/ati_fts_offline.cc
+
+      ${CMAKE_BINARY_DIR}/fastcat/autogen/fastcat_devices/commander.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/signal_generator.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/function.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/conditional.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/pid.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/saturation.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/schmitt_trigger.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/filter.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/fts.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/virtual_fts.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/faulter.cc
+      ${PROJECT_SOURCE_DIR}/src/fastcat_devices/linear_interpolation.cc
       )
   target_include_directories(${ARGV0} PUBLIC
       ${CMAKE_BINARY_DIR}/include
@@ -135,9 +134,3 @@ endmacro()
 
 create_fastcat_lib(fastcat)
 target_compile_definitions(fastcat PUBLIC PROTECTED=protected PRIVATE=private)
-
-if(BUILD_TESTS)
-    create_fastcat_lib(fastcat-test)
-    message("fastcat-test: Overriding protected and private class methods for internal unit testing")
-    target_compile_definitions(fastcat-test PUBLIC PROTECTED=public PRIVATE=public)
-endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,9 +58,7 @@ add_custom_target(fcgen
     )
 
 # Build a library regardless of BUILD_TESTS flag
-add_definitions(-DPROTECTED=protected)
-add_definitions(-DPRIVATE=private)
-add_library(fastcat STATIC
+set(FASTCAT_SOURCES
     trap.c
     device_base.cc
     manager.cc
@@ -113,20 +111,33 @@ add_library(fastcat STATIC
     fastcat_devices/virtual_fts.cc
     fastcat_devices/faulter.cc
     fastcat_devices/linear_interpolation.cc
-    )
+)
 
-target_include_directories(
-    fastcat PUBLIC
-    ${CMAKE_BINARY_DIR}/include
-    ${SOEM_INCLUDE_DIRS}
-    )
+macro(create_fastcat_lib)
+  message("creating library: ${ARGV0}")
+  add_library(${ARGV0} STATIC
+     ${FASTCAT_SOURCES}
+      )
+  target_include_directories(${ARGV0} PUBLIC
+      ${CMAKE_BINARY_DIR}/include
+      ${SOEM_INCLUDE_DIRS}
+      )
+  
+  target_link_libraries(${ARGV0}
+      jsd-lib
+      ${YAMLCPP_LIBRARY}
+      )
+  
+  add_dependencies(${ARGV0}
+      fcgen
+      )
+endmacro()
 
-target_link_libraries(fastcat
-    jsd-lib
-    ${YAMLCPP_LIBRARY}
-    )
+create_fastcat_lib(fastcat)
+target_compile_definitions(fastcat PUBLIC PROTECTED=protected PRIVATE=private)
 
-add_dependencies(fastcat
-    fcgen
-    )
-
+if(BUILD_TESTS)
+    create_fastcat_lib(fastcat-test)
+    message("fastcat-test: Overriding protected and private class methods for internal unit testing"
+    target_compile_definitions(fastcat-test PUBLIC PROTECTED=public PRIVATE=public)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,16 +4,13 @@ message("Building tests, disable with BUILD_TESTS CMake option")
 ## Simple C Test Programs ##
 ############################
 
-add_definitions(-DPROTECTED=public)
-add_definitions(-DPRIVATE=public)
-
 include_directories(
     ${READLINE_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}/include
     )
 
 set(fastcat_test_libs
-    fastcat
+    fastcat-test
     m
     -lreadline
     )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 message("Building tests, disable with BUILD_TESTS CMake option")
 
+create_fastcat_lib(fastcat-test)
+message("fastcat-test: Overriding protected and private class methods for internal unit testing")
+target_compile_definitions(fastcat-test PUBLIC PROTECTED=public PRIVATE=public)
+
 ############################
 ## Simple C Test Programs ##
 ############################

--- a/test/fastcat_test_app/CMakeLists.txt
+++ b/test/fastcat_test_app/CMakeLists.txt
@@ -19,3 +19,16 @@ add_executable(ftest
 )
 
 target_link_libraries(ftest fastcat)
+
+
+# Test that the protected and private overrides work properly
+#add_executable(ftest-invalid-access
+#  ftest_invalid_access.cc
+#)
+#target_link_libraries(ftest-invalid-access fastcat)
+
+# Test that the fastcat-test lib is not available to applications by accident
+add_executable(ftest-invalid-access-lib
+  ftest_invalid_access.cc
+)
+target_link_libraries(ftest-invalid-access-lib fastcat-test)

--- a/test/fastcat_test_app/CMakeLists.txt
+++ b/test/fastcat_test_app/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 FetchContent_Declare(
   fastcat
   GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
-  GIT_TAG apb-ut-visibility-declarations
+  GIT_TAG master
 )
 FetchContent_MakeAvailable(fastcat)
 
@@ -28,7 +28,7 @@ target_link_libraries(ftest fastcat)
 #target_link_libraries(ftest-invalid-access fastcat)
 
 # Test that the fastcat-test lib is not available to applications by accident
-add_executable(ftest-invalid-access-lib
-  ftest_invalid_access.cc
-)
-target_link_libraries(ftest-invalid-access-lib fastcat-test)
+#add_executable(ftest-invalid-access-lib
+#  ftest_invalid_access.cc
+#)
+#target_link_libraries(ftest-invalid-access-lib fastcat-test)

--- a/test/fastcat_test_app/CMakeLists.txt
+++ b/test/fastcat_test_app/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(fastcat_test_app
+  VERSION 0.0.0
+  LANGUAGES C CXX
+  DESCRIPTION "Fastcat test C++ app"
+)
+
+include(FetchContent)
+FetchContent_Declare(
+  fastcat
+  GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
+  GIT_TAG master
+)
+FetchContent_MakeAvailable(fastcat)
+
+add_executable(ftest
+  ftest.cc
+)
+
+target_link_libraries(ftest fastcat)

--- a/test/fastcat_test_app/CMakeLists.txt
+++ b/test/fastcat_test_app/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 FetchContent_Declare(
   fastcat
   GIT_REPOSITORY https://github.com/nasa-jpl/fastcat.git
-  GIT_TAG master
+  GIT_TAG apb-ut-visibility-declarations
 )
 FetchContent_MakeAvailable(fastcat)
 

--- a/test/fastcat_test_app/README.md
+++ b/test/fastcat_test_app/README.md
@@ -41,3 +41,17 @@ make[1]: *** [CMakeFiles/Makefile2:223: CMakeFiles/ftest-invalid-access.dir/all]
 make: *** [Makefile:136: all] Error 2
 
 ```
+
+And this is the output for the 2nd executable `ftest-invalid-access-lib` which aims to link against the library `fastcat-test` instead of the proper `fastcat` target library:
+```
+# Test that the fastcat-test lib is not available to applications by accident
+
+[ 94%] Building CXX object CMakeFiles/ftest-invalid-access-lib.dir/ftest_invalid_access.cc.o
+/home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/ftest_invalid_access.cc:2:10: fatal error: fastcat/fastcat.h: No such file or directory
+    2 | #include "fastcat/fastcat.h"
+      |          ^~~~~~~~~~~~~~~~~~~
+compilation terminated.
+make[2]: *** [CMakeFiles/ftest-invalid-access-lib.dir/build.make:76: CMakeFiles/ftest-invalid-access-lib.dir/ftest_invalid_access.cc.o] Error 1
+make[1]: *** [CMakeFiles/Makefile2:217: CMakeFiles/ftest-invalid-access-lib.dir/all] Error 2
+make: *** [Makefile:136: all] Error 2
+```

--- a/test/fastcat_test_app/README.md
+++ b/test/fastcat_test_app/README.md
@@ -1,0 +1,43 @@
+# fastcat Test Application
+
+Minimal test application to ensure the library presents to applications as expected.
+
+Test it out with:
+``` bash
+mkdir build
+cd build
+cmake ..
+make
+```
+Feel free to tailor the CMakeLists.txt to suit your testing needs. Leaving it pinned to master branch since that's the only branch that is guaranteed to always exist.
+
+Here's an example output of expected output for an application that is trying to improperly use the private and protected methods or the interally build `fastcat-test` library
+
+
+``` text
+# Test that the protected and private overrides work properly
+
+/home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/ftest_invalid_access.cc: In function ‘int main()’:
+/home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/ftest_invalid_access.cc:9:15: error: ‘double fastcat::Actuator::CntsToEu(int32_t)’ is protected within this context
+    9 |   act.CntsToEu(100); // protected
+      |   ~~~~~~~~~~~~^~~~~
+In file included from /home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/build/include/fastcat/manager.h:16,
+                 from /home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/build/include/fastcat/fastcat.h:4,
+                 from /home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/ftest_invalid_access.cc:2:
+/home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/build/include/fastcat/jsd/actuator.h:102:11: note: declared protected here
+  102 |   double  CntsToEu(int32_t cnts);
+      |           ^~~~~~~~
+/home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/ftest_invalid_access.cc:10:18: error: ‘bool fastcat::Actuator::prof_pos_hold_’ is private within this context
+   10 |   bool val = act.prof_pos_hold_; // private
+      |                  ^~~~~~~~~~~~~~
+In file included from /home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/build/include/fastcat/manager.h:16,
+                 from /home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/build/include/fastcat/fastcat.h:4,
+                 from /home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/ftest_invalid_access.cc:2:
+/home/abrinkma/src/fastcat_ws/fastcat-uts/test/fastcat_test_app/build/include/fastcat/jsd/actuator.h:183:8: note: declared private here
+  183 |   bool prof_pos_hold_;
+      |        ^~~~~~~~~~~~~~
+make[2]: *** [CMakeFiles/ftest-invalid-access.dir/build.make:76: CMakeFiles/ftest-invalid-access.dir/ftest_invalid_access.cc.o] Error 1
+make[1]: *** [CMakeFiles/Makefile2:223: CMakeFiles/ftest-invalid-access.dir/all] Error 2
+make: *** [Makefile:136: all] Error 2
+
+```

--- a/test/fastcat_test_app/ftest.cc
+++ b/test/fastcat_test_app/ftest.cc
@@ -1,0 +1,9 @@
+#include "fastcat/fastcat.h"
+#include "fastcat/jsd/actuator.h"
+
+int main(){
+  fastcat::Manager manager;
+  fastcat::Actuator act;
+ 
+  printf("done.");
+}

--- a/test/fastcat_test_app/ftest_invalid_access.cc
+++ b/test/fastcat_test_app/ftest_invalid_access.cc
@@ -1,9 +1,13 @@
+
 #include "fastcat/fastcat.h"
 #include "fastcat/jsd/actuator.h"
 
 int main(){
   fastcat::Manager manager;
   fastcat::Actuator act;
+
+  act.CntsToEu(100); // protected
+  bool val = act.prof_pos_hold_; // private
  
-  printf("done.\n");
+  printf("done.");
 }

--- a/test/test_unit/CMakeLists.txt
+++ b/test/test_unit/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(TEST_SOURCE ${TEST_SOURCES})
         ${TEST_EXECUTABLE} PRIVATE
         ${GTEST_BOTH_LIBRARIES}
         Threads::Threads
-        fastcat
+        fastcat-test
         )
     target_include_directories(
         ${TEST_EXECUTABLE} PUBLIC


### PR DESCRIPTION
One possible way of overloading private and protected methods to enable fine-grained unit testing.
Add a test package at `test/fastcat_test_app` that was used to confirm the `fastcat` library presents in the expected way to downstream applications. 

Just bump minor version on these changes.