### PR TITLE
use gcc-specific -fno-access-control to defeat protected and private 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,8 +58,6 @@ add_custom_target(fcgen
     )
 
 # Build a library regardless of BUILD_TESTS flag
-add_definitions(-DPROTECTED=protected)
-add_definitions(-DPRIVATE=private)
 add_library(fastcat STATIC
     trap.c
     device_base.cc

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -50,6 +50,7 @@ typedef enum {
 
 class Actuator : public JsdDeviceBase
 {
+
  public:
   Actuator();
 
@@ -97,7 +98,7 @@ class Actuator : public JsdDeviceBase
 
   const ActuatorParams& GetParams() { return params_; }
 
- PROTECTED:
+ protected:
 
   double  CntsToEu(int32_t cnts);
   int32_t EuToCnts(double eu);
@@ -176,7 +177,7 @@ class Actuator : public JsdDeviceBase
   ActuatorCalibrateCmd cal_cmd_;
   ActuatorParams       params_;
 
-PRIVATE:
+ private:
   bool GSModeFromString(std::string                     gs_mode_string,
                         jsd_egd_gain_scheduling_mode_t& gs_mode);
 

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -50,7 +50,6 @@ typedef enum {
 
 class Actuator : public JsdDeviceBase
 {
-
  public:
   Actuator();
 

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -12,6 +12,9 @@ namespace fastcat
 {
 class ActuatorOffline : public Actuator
 {
+
+  friend class ActuatorTest;
+
  public:
   ActuatorOffline();
 

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -13,8 +13,6 @@ namespace fastcat
 class ActuatorOffline : public Actuator
 {
 
-  friend class ActuatorTest;
-
  public:
   ActuatorOffline();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,9 +4,6 @@ message("Building tests, disable with BUILD_TESTS CMake option")
 ## Simple C Test Programs ##
 ############################
 
-add_definitions(-DPROTECTED=public)
-add_definitions(-DPRIVATE=public)
-
 include_directories(
     ${READLINE_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}/include

--- a/test/test_unit/CMakeLists.txt
+++ b/test/test_unit/CMakeLists.txt
@@ -39,6 +39,7 @@ foreach(TEST_SOURCE ${TEST_SOURCES})
         NAME ${TEST_EXECUTABLE}
         COMMAND ${TEST_EXECUTABLE}
         )
+    target_compile_options(${TEST_EXECUTABLE} PRIVATE -fno-access-control)
 
 endforeach()
 

--- a/test/test_unit/test_actuator.cc
+++ b/test/test_unit/test_actuator.cc
@@ -7,7 +7,7 @@
 #include "fastcat/signal_handling.h"
 #include "jsd/jsd_print.h"
 
-namespace
+namespace fastcat
 {
 class ActuatorTest : public ::testing::Test
 {


### PR DESCRIPTION
Use this for now until I can invent some clever global friend function