### PR TITLE
Apb ut friend 2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,8 +58,6 @@ add_custom_target(fcgen
     )
 
 # Build a library regardless of BUILD_TESTS flag
-add_definitions(-DPROTECTED=protected)
-add_definitions(-DPRIVATE=private)
 add_library(fastcat STATIC
     trap.c
     device_base.cc

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -50,6 +50,7 @@ typedef enum {
 
 class Actuator : public JsdDeviceBase
 {
+
  public:
   Actuator();
 
@@ -97,7 +98,7 @@ class Actuator : public JsdDeviceBase
 
   const ActuatorParams& GetParams() { return params_; }
 
- PROTECTED:
+ protected:
 
   double  CntsToEu(int32_t cnts);
   int32_t EuToCnts(double eu);
@@ -176,7 +177,7 @@ class Actuator : public JsdDeviceBase
   ActuatorCalibrateCmd cal_cmd_;
   ActuatorParams       params_;
 
-PRIVATE:
+ private:
   bool GSModeFromString(std::string                     gs_mode_string,
                         jsd_egd_gain_scheduling_mode_t& gs_mode);
 

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -50,7 +50,6 @@ typedef enum {
 
 class Actuator : public JsdDeviceBase
 {
-
  public:
   Actuator();
 

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -50,6 +50,9 @@ typedef enum {
 
 class Actuator : public JsdDeviceBase
 {
+ 
+ friend class Tester;
+
  public:
   Actuator();
 

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -12,6 +12,9 @@ namespace fastcat
 {
 class ActuatorOffline : public Actuator
 {
+
+  friend class ActuatorTest;
+
  public:
   ActuatorOffline();
 

--- a/src/jsd/actuator_offline.h
+++ b/src/jsd/actuator_offline.h
@@ -13,8 +13,6 @@ namespace fastcat
 class ActuatorOffline : public Actuator
 {
 
-  friend class ActuatorTest;
-
  public:
   ActuatorOffline();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,9 +4,6 @@ message("Building tests, disable with BUILD_TESTS CMake option")
 ## Simple C Test Programs ##
 ############################
 
-add_definitions(-DPROTECTED=public)
-add_definitions(-DPRIVATE=public)
-
 include_directories(
     ${READLINE_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}/include

--- a/test/test_unit/CMakeLists.txt
+++ b/test/test_unit/CMakeLists.txt
@@ -39,7 +39,6 @@ foreach(TEST_SOURCE ${TEST_SOURCES})
         NAME ${TEST_EXECUTABLE}
         COMMAND ${TEST_EXECUTABLE}
         )
-    target_compile_options(${TEST_EXECUTABLE} PRIVATE -fno-access-control)
 
 endforeach()
 

--- a/test/test_unit/CMakeLists.txt
+++ b/test/test_unit/CMakeLists.txt
@@ -39,6 +39,7 @@ foreach(TEST_SOURCE ${TEST_SOURCES})
         NAME ${TEST_EXECUTABLE}
         COMMAND ${TEST_EXECUTABLE}
         )
+    target_compile_options(${TEST_EXECUTABLE} PRIVATE -fno-access-control)
 
 endforeach()
 

--- a/test/test_unit/test_actuator.cc
+++ b/test/test_unit/test_actuator.cc
@@ -9,6 +9,30 @@
 
 namespace fastcat
 {
+
+class Tester {
+  public:
+  jsd_egd_state_t* GetEgdState(Actuator& device){
+    return &device.jsd_egd_state_;
+  }
+  
+  ActuatorStateMachineState GetSMS(Actuator& device){
+    return device.actuator_sms_;
+  }
+
+  
+  double  CntsToEu(Actuator& device, int32_t cnts){
+    return device.CntsToEu(cnts);
+  }
+
+  double  PosCntsToEu(Actuator& device, int32_t cnts){
+    return device.PosCntsToEu(cnts);
+  }
+
+};
+
+Tester tester;
+
 class ActuatorTest : public ::testing::Test
 {
  protected:
@@ -159,10 +183,10 @@ TEST_F(ActuatorTest, RejectMotionCommandsWhenFaulted)
   TEST_F(ActuatorTest, NominalResetFunction) {
     EXPECT_TRUE(device_.ConfigFromYaml(YAML::LoadFile(base_dir_+"valid.yaml")));
     device_.Fault();    
-    EXPECT_TRUE(device_.actuator_sms_ == fastcat::ACTUATOR_SMS_FAULTED);
+    EXPECT_TRUE(tester.GetSMS(device_) == fastcat::ACTUATOR_SMS_FAULTED);
 
     device_.Reset();
-    EXPECT_TRUE(device_.actuator_sms_ == fastcat::ACTUATOR_SMS_HALTED);
+    EXPECT_TRUE(tester.GetSMS(device_) == fastcat::ACTUATOR_SMS_HALTED);
   }
 
   TEST_F(ActuatorTest, FixDirtyCmdVelocityValues) {
@@ -170,12 +194,15 @@ TEST_F(ActuatorTest, RejectMotionCommandsWhenFaulted)
     // Set the jsd egd device state to known, dirty values
     // TODO setup for pos, and current values too
 
-    device_.jsd_egd_state_.cmd_position = 1234;
-    device_.jsd_egd_state_.cmd_velocity = 1234;
-    device_.jsd_egd_state_.cmd_current = 1234;
     
-    double expected_pos = device_.PosCntsToEu(1234);
-    double expected_vel = device_.CntsToEu(1234);
+    jsd_egd_state_t* jsd_egd_state = tester.GetEgdState(device_);
+
+    jsd_egd_state->cmd_position = 1234;
+    jsd_egd_state->cmd_velocity = 1234;
+    jsd_egd_state->cmd_current = 1234;
+    
+    double expected_pos = tester.PosCntsToEu(device_, 1234);
+    double expected_vel = tester.CntsToEu(device_, 1234);
     double expected_cur = 1234;
     
     device_.Read();

--- a/test/test_unit/test_actuator.cc
+++ b/test/test_unit/test_actuator.cc
@@ -7,7 +7,7 @@
 #include "fastcat/signal_handling.h"
 #include "jsd/jsd_print.h"
 
-namespace
+namespace fastcat
 {
 class ActuatorTest : public ::testing::Test
 {


### PR DESCRIPTION
Added proper `Tester` friend class that can be used to generalize access to protected and private fields/methods in the device class. 