### PR TITLE
Add external_time optional argument to Process

### DIFF
--- a/src/manager.cc
+++ b/src/manager.cc
@@ -214,7 +214,7 @@ bool fastcat::Manager::ConfigFromYaml(YAML::Node node)
   return true;
 }
 
-bool fastcat::Manager::Process()
+bool fastcat::Manager::Process(double external_time)
 {
   for (auto it = jsd_map_.begin(); it != jsd_map_.end(); ++it) {
     jsd_read(it->second, 1e6 / target_loop_rate_hz_);
@@ -222,7 +222,15 @@ bool fastcat::Manager::Process()
 
   // Pass the PDO read time for consistent timestamping before the device Read()
   //   method is invoked
-  double read_time = jsd_time_get_time_sec();
+  double read_time;
+  if (external_time > -1e9 && external_time < 1e9)
+  { // external time is zero so use JSD time
+    read_time = jsd_time_get_time_sec();
+  }
+  else
+  { // use supplied external time
+    read_time = external_time;
+  }
 
   for (auto it = jsd_device_list_.begin(); it != jsd_device_list_.end(); ++it) {
     (*it)->SetTime(read_time);

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -396,8 +396,6 @@ bool fastcat::Manager::ConfigJSDBusFromYaml(YAML::Node node)
     return false;
   }
 
-  online_devices_exist_ = true;
-
   jsd_t* jsd = jsd_alloc();
 
   JSDPair pair(ifname, jsd);
@@ -485,6 +483,8 @@ bool fastcat::Manager::ConfigJSDBusFromYaml(YAML::Node node)
     if (!CheckDeviceNameIsUnique(device->GetName())) {
       return false;
     }
+
+    online_devices_exist_ = true;
 
     DevicePair pair(device->GetName(), device);
     device_map_.insert(pair);

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -223,13 +223,14 @@ bool fastcat::Manager::Process(double external_time)
   // Pass the PDO read time for consistent timestamping before the device Read()
   //   method is invoked
   double read_time;
-  if (external_time > -1e9 && external_time < 1e9)
-  { // external time is zero so use JSD time
-    read_time = jsd_time_get_time_sec();
-  }
-  else
-  { // use supplied external time
+  if (external_time > 0) {
+    if (online_devices_exist_) {
+      ERROR("Applications cannot use online devices and supply external time, refusing to run");
+      return false;
+    }
     read_time = external_time;
+  } else {
+    read_time = jsd_time_get_time_sec();
   }
 
   for (auto it = jsd_device_list_.begin(); it != jsd_device_list_.end(); ++it) {
@@ -394,6 +395,8 @@ bool fastcat::Manager::ConfigJSDBusFromYaml(YAML::Node node)
   if (!ParseList(node, "devices", devices_node)) {
     return false;
   }
+
+  online_devices_exist_ = true;
 
   jsd_t* jsd = jsd_alloc();
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -66,7 +66,7 @@ class Manager
    *   @return Return true if bus is not faulted, otherwise a bus fault is
    * active.
    */
-  bool Process(double process_time=0);
+  bool Process(double external_time=0.0);
 
   /** @brief Interface to command devices on the bus
    *

--- a/src/manager.h
+++ b/src/manager.h
@@ -62,11 +62,13 @@ class Manager
    * Manager::Process() function at the same frequency as the input YAML field
    * `target_loop_rate_hz`. This parameter is needed by certain devices for
    * profiling and filtering.
-   *
+   *   
+   *   @param external_time Supply an external time if desired, otherwise
+   *          defaults to jsd supplied system time
    *   @return Return true if bus is not faulted, otherwise a bus fault is
    * active.
    */
-  bool Process(double external_time=0.0);
+  bool Process(double external_time = -1);
 
   /** @brief Interface to command devices on the bus
    *
@@ -196,6 +198,7 @@ class Manager
   bool                          zero_latency_required_              = true;
   bool                          faulted_                            = false;
   bool                          actuator_fault_on_missing_pos_file_ = true;
+  bool                          online_devices_exist_               = false;
   std::string                   actuator_position_directory_;
   std::map<std::string, jsd_t*> jsd_map_;
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -66,7 +66,7 @@ class Manager
    *   @return Return true if bus is not faulted, otherwise a bus fault is
    * active.
    */
-  bool Process();
+  bool Process(double process_time=0);
 
   /** @brief Interface to command devices on the bus
    *


### PR DESCRIPTION
As per previous discussion, allow an external source for process time, such as in case of using FastCAT with a non realtime simulation engine.