### PR TITLE
Fix correct signal update

### DIFF
--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -29,7 +29,7 @@ For every `JSD Device` there is an `Offline Device` to emulate the behavior of t
 | Conditional     | Logical test for signal with a boolean state data field      |
 | Faulter         | Emits a fault if a the input signal != 0                     |
 | Filter          | Supports Digital AB and Moving Average filtering on Signals  |
-| Fts             | Reads in 6 'raw' signals and multiplies them through a 6x6 calibration matrix to compute a wrench |
+| Fts             | Reads in N (some number >=6) 'raw' signals and multiplies them through a 6xN calibration matrix to compute a wrench |
 | Function        | Applies a function to a single input signal (e.g. parametrized N-order polynomial) |
 | Pid             | Applies a PID Controller to signal with deadband and persistence arguments |
 | Saturation      | Applies upper and lower saturation limits to a signal        |

--- a/src/fastcat_devices/fts.cc
+++ b/src/fastcat_devices/fts.cc
@@ -100,14 +100,11 @@ bool fastcat::Fts::ConfigFromYaml(YAML::Node node)
 
 bool fastcat::Fts::Read()
 {
-  int i= 0;
   for (auto& signal : signals_) {
     if (!UpdateSignal(signal)) {
       ERROR("Could not extract signal");
       return false;
     }
-    MSG_DEBUG("Signal number %d is value %f", i, signal.value);
-    i++;
   }
 
   for (int ii = 0; ii < FC_FTS_N_DIMS; ii++) {

--- a/src/fastcat_devices/fts.cc
+++ b/src/fastcat_devices/fts.cc
@@ -78,7 +78,7 @@ bool fastcat::Fts::ConfigFromYaml(YAML::Node node)
 
   size_t el = 0;
   for (auto cc = calib_node.begin(); cc != calib_node.end(); ++cc) {
-    calibration_[el / FC_FTS_N_DIMS][el % signals_.size()] = (*cc).as<double>();
+    calibration_[el / signals_.size()][el % signals_.size()] = (*cc).as<double>();
     el++;
   }
 
@@ -100,11 +100,17 @@ bool fastcat::Fts::ConfigFromYaml(YAML::Node node)
 
 bool fastcat::Fts::Read()
 {
-  for (int ii = 0; ii < FC_FTS_N_DIMS; ii++) {
-    if (!UpdateSignal(signals_[ii])) {
+  int i= 0;
+  for (auto& signal : signals_) {
+    if (!UpdateSignal(signal)) {
       ERROR("Could not extract signal");
       return false;
     }
+    MSG_DEBUG("Signal number %d is value %f", i, signal.value);
+    i++;
+  }
+
+  for (int ii = 0; ii < FC_FTS_N_DIMS; ii++) {
     wrench_[ii] = 0;
 
     for (size_t jj = 0; jj < signals_.size(); jj++) {

--- a/test/test_unit/test_fts.cc
+++ b/test/test_unit/test_fts.cc
@@ -45,3 +45,31 @@ TEST_F(FtsTest, RejectTareWhenFaulted)
   cmd.type = fastcat::FTS_TARE_CMD;
   EXPECT_FALSE(device_.Write(cmd));
 }
+
+TEST_F(FtsTest, WideMatrixValid)
+{
+  MSG_DEBUG("before parse");
+  EXPECT_TRUE(
+      device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "fts_wide_cal_matrix.yaml")));
+
+  // Zero out all signals
+  std::vector<fastcat::DeviceState> device_states(device_.signals_.size());
+  for (int i=0; i<(int)device_.signals_.size(); i++) 
+  { 
+    auto &sgs = device_states[i]; 
+    sgs.type = fastcat::SIGNAL_GENERATOR_STATE;
+    sgs.signal_generator_state.output = 0.0;
+    device_states.push_back(sgs);
+    fastcat::ConfigSignalByteIndexing(&sgs, device_.signals_[i]);
+  }
+  device_.Read();
+  EXPECT_EQ(
+    0.0, device_.GetState()->fts_state.raw_tz);
+
+  // Make non-zero final signal
+  auto &last_state = device_states.back();
+  last_state.signal_generator_state.output = 10.0;
+  device_.Read();
+  EXPECT_EQ(
+    35.0, device_.GetState()->fts_state.raw_tz);
+}

--- a/test/test_unit/test_fts.cc
+++ b/test/test_unit/test_fts.cc
@@ -48,7 +48,6 @@ TEST_F(FtsTest, RejectTareWhenFaulted)
 
 TEST_F(FtsTest, WideMatrixValid)
 {
-  MSG_DEBUG("before parse");
   EXPECT_TRUE(
       device_.ConfigFromYaml(YAML::LoadFile(base_dir_ + "fts_wide_cal_matrix.yaml")));
 
@@ -59,7 +58,6 @@ TEST_F(FtsTest, WideMatrixValid)
     auto &sgs = device_states[i]; 
     sgs.type = fastcat::SIGNAL_GENERATOR_STATE;
     sgs.signal_generator_state.output = 0.0;
-    device_states.push_back(sgs);
     fastcat::ConfigSignalByteIndexing(&sgs, device_.signals_[i]);
   }
   device_.Read();
@@ -68,7 +66,7 @@ TEST_F(FtsTest, WideMatrixValid)
 
   // Make non-zero final signal
   auto &last_state = device_states.back();
-  last_state.signal_generator_state.output = 10.0;
+  last_state.signal_generator_state.output = 35.0;
   device_.Read();
   EXPECT_EQ(
     35.0, device_.GetState()->fts_state.raw_tz);

--- a/test/test_unit/test_fts_yamls/fts_wide_cal_matrix.yaml
+++ b/test/test_unit/test_fts_yamls/fts_wide_cal_matrix.yaml
@@ -1,0 +1,29 @@
+device_class: Fts
+name: fts_2
+calibration_matrix: [1,0,0,0,0,0,0,
+                     0,1,0,0,0,0,0,
+                     0,0,1,0,0,0,0,
+                     0,0,0,1,0,0,0,
+                     0,0,0,0,1,0,0,
+                     0,0,0,0,0,1,1]
+max_force_x:  100
+max_force_y:  200
+max_force_z:  300
+max_torque_x: 10
+max_torque_y: 20
+max_torque_z: 30
+signals:
+- observed_device_name: sig_gen_1
+  request_signal_name: output
+- observed_device_name: sig_gen_2
+  request_signal_name: output
+- observed_device_name: sig_gen_3
+  request_signal_name: output
+- observed_device_name: sig_gen_4
+  request_signal_name: output
+- observed_device_name: sig_gen_5
+  request_signal_name: output
+- observed_device_name: sig_gen_6
+  request_signal_name: output
+- observed_device_name: sig_gen_7
+  request_signal_name: output


### PR DESCRIPTION
Going through the code, we surmised that calibration matrices with number of signals greater than 6 was not supported. Though the documentation (the previous state of the README), coincides with this, Fts should allow for more than 6 input signals.
These changes give a test that show that with a varying 7th signal, updates are now properly reflected by the UpdateSignals function.