### PR TITLE
Add three node motor thermal model

### DIFF
--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -1151,7 +1151,7 @@ This example implements an absolute value function over the range of [-9, 9]
 | winding_thermal_cor      | The thermal coefficient of resistance (% / deg C) |
 | k1      | Weight for for node 1 used for the weighted-average temperature estimate of node |
 | k3      | Weight for for node 3 used for the weighted-average temperature estimate of node |
-| persistance_limit      | The number of allowable cycles to occur at or above the a temperature threshold before faulting |
+| persistence_limit      | The number of allowable cycles to occur at or above the a temperature threshold before faulting |
 | max_allowable_temps      | An array of allow able temperatures at each node (in order) |
 
 The ThreeNodeThermalModel provides a simplified predictive thermal model used to estimate 
@@ -1161,9 +1161,7 @@ damage it's operation. The maximum allowable temperature at each node is prescri
 `max_allowable_temps` parameter supplied to this device.
 
 If the temperature at any one node exceeds the specified max temperature for more the number
-of cycles specified by `persistance_limit`, then a Fastcat fault is emitted.
-
-**TODO:** determine how to add the ability to re-seed the temperatures at each node (useful for restarts of tests when sufficient time to dissipate heat hasn't occcured) 
+of cycles specified by `persistence_limit`, then a Fastcat fault is emitted.
 
 ### Example
 
@@ -1178,7 +1176,7 @@ of cycles specified by `persistance_limit`, then a Fastcat fault is emitted.
   winding_thermal_cor: 6.0
   k1: 1.0
   k3: 2.0
-  persistance_limit: 5
+  persistence_limit: 5
   max_allowable_temps: [65.0, 70.0, 75.0, 80.0]
   signals:
   - observed_device_name: el3602

--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -1137,3 +1137,52 @@ This example implements an absolute value function over the range of [-9, 9]
   - observed_device_name: sig_gen_1
     request_signal_name:  output
 ```
+
+
+## ThreeNodeThermalModel
+
+| Parameter   | Description |
+| ----------- | ----------- |
+| thermal_mass_node_1      | The thermal mass that represents the winding node (node 1) |
+| thermal_mass_node_2      | The thermal mass that represents the stator node (node 2) |
+| thermal_res_nodes_1_to_2      | The effective thermal resistance between nodes 1 and 2 |
+| thermal_res_nodes_2_to_3      | The effective thermal resistance between nodes 2 and 3 |
+| winding_res      | The electrical resistance of the motor windings at 20 deg C |
+| winding_thermal_cor      | The thermal coefficient of resistance (% / deg C) |
+| k1      | Weight for for node 1 used for the weighted-average temperature estimate of node |
+| k3      | Weight for for node 3 used for the weighted-average temperature estimate of node |
+| persistance_limit      | The number of allowable cycles to occur at or above the a temperature threshold before faulting |
+| max_allowable_temps      | An array of allow able temperatures at each node (in order) |
+
+The ThreeNodeThermalModel provides a simplified predictive thermal model used to estimate 
+temperature change over time in specific locations in a motor. This is primarily useful for
+estimating when a motor's internal temperature is at risk of exceeding a threshold that could
+damage it's operation. The maximum allowable temperature at each node is prescribable in the 
+`max_allowable_temps` parameter supplied to this device.
+
+If the temperature at any one node exceeds the specified max temperature for more the number
+of cycles specified by `persistance_limit`, then a Fastcat fault is emitted.
+
+**TODO:** determine how to add the ability to re-seed the temperatures at each node (useful for restarts of tests when sufficient time to dissipate heat hasn't occcured) 
+
+### Example
+
+``` yaml
+- device_class: ThreeNodeThermalModel
+  name:         three_node_thermal_model_1 
+  thermal_mass_node_1: 1.0
+  thermal_mass_node_2: 2.0
+  thermal_res_nodes_1_to_2: 3.0
+  thermal_res_nodes_2_to_3: 4.0
+  winding_res: 5.0
+  winding_thermal_cor: 6.0
+  k1: 1.0
+  k3: 2.0
+  persistance_limit: 5
+  max_allowable_temps: [65.0, 70.0, 75.0, 80.0]
+  signals:
+  - observed_device_name: el3602
+    request_signal_name:  voltage_ch1
+  - observed_device_name: egd_1
+    request_signal_name:  actual_current
+```

--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -297,3 +297,26 @@ buses:
       signals:
       - observed_device_name: sig_gen_1
         request_signal_name:  output
+
+    - device_class: ThreeNodeThermalModel
+      name:         three_node_thermal_model_1 
+      thermal_mass_node_1: 1.0
+      thermal_mass_node_2: 2.0
+      thermal_res_nodes_1_to_2: 3.0
+      thermal_res_nodes_2_to_3: 4.0
+      winding_res: 5.0
+      winding_thermal_cor: 6.0
+      k1: 1.0
+      k3: 2.0
+      max_allowable_temp_1: 65.0
+      max_allowable_temp_1: 70.0
+      max_allowable_temp_1: 75.0
+      max_allowable_temp_1: 80.0
+      persistance_limit: 5
+      signals:
+      - observed_device_name: el3602
+        request_signal_name:  voltage_ch1
+      - observed_device_name: egd_1
+        request_signal_name:  actual_current
+
+

--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -308,11 +308,8 @@ buses:
       winding_thermal_cor: 6.0
       k1: 1.0
       k3: 2.0
-      max_allowable_temp_1: 65.0
-      max_allowable_temp_1: 70.0
-      max_allowable_temp_1: 75.0
-      max_allowable_temp_1: 80.0
       persistance_limit: 5
+      max_allowable_temps: [65.0, 70.0, 75.0, 80.0]
       signals:
       - observed_device_name: el3602
         request_signal_name:  voltage_ch1

--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -308,7 +308,7 @@ buses:
       winding_thermal_cor: 6.0
       k1: 1.0
       k3: 2.0
-      persistance_limit: 5
+      persistence_limit: 5
       max_allowable_temps: [65.0, 70.0, 75.0, 80.0]
       signals:
       - observed_device_name: el3602

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(fastcat STATIC
     fastcat_devices/virtual_fts.cc
     fastcat_devices/faulter.cc
     fastcat_devices/linear_interpolation.cc
+    fastcat_devices/three_node_thermal_model.cc
     )
 
 target_include_directories(

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -1,0 +1,28 @@
+// Include related header (for cc files)
+#include "fastcat/fastcat_devices/three_node_thermal_model.h"
+
+namespace fastcat
+{
+ThreeNodeThermalModel::Fts()
+{
+  state_       = std::make_shared<DeviceState>();
+  state_->type = THREE_NODE_THERMAL_MODEL_STATE;
+  // TODO: any other class setup
+}
+
+bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
+{
+  if (!ParseVal(node, "name", name_)) {
+    return false;
+  }
+  state_->name = name_;
+
+  // TODO
+}
+
+bool Read() {}
+
+FaultType Process() {}
+
+bool Write(DeviceCmd& cmd) {}
+}  // namespace fastcat

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -17,7 +17,54 @@ bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
   }
   state_->name = name_;
 
-  // TODO
+  if (!ParseVal(node, "thermal_mass_node_1", thermal_mass_node_1_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "thermal_mass_node_2", thermal_mass_node_2_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "thermal_res_nodes_1_to_2", thermal_res_nodes_1_to_2_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "thermal_res_nodes_2_to_3", thermal_res_nodes_2_to_3_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "winding_res", winding_res_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "winding_thermal_cor", winding_thermal_cor_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "k1", k1_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "persistance_limit", persistance_limit_)) {
+    return false;
+  }
+
+  YAML::Node max_allowable_temp_node;
+  if (!ParseList(node, "max_allowable_temps", max_allowable_temp_node)) {
+    return false;
+  }
+
+  if (max_allowable_temp_node.size() != max_allowable_temps_.size()) {
+    ERROR("There must be exactly 4 temperature limit values provided");
+    return false;
+  }
+
+  for (size_t idx = 0; idx < max_allowable_temp_node.size(); ++idx) {
+    max_allowable_temps_[idx] = max_allowable_temp_node[idx].as<double>();
+  }
+
+  // TODO: validate signal size proviced in yaml
+  return true;
 }
 
 bool Read() {}

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -7,7 +7,6 @@ ThreeNodeThermalModel::ThreeNodeThermalModel()
 {
   state_       = std::make_shared<DeviceState>();
   state_->type = THREE_NODE_THERMAL_MODEL_STATE;
-  // TODO: any other class setup
 }
 
 bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
@@ -45,7 +44,11 @@ bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if (!ParseVal(node, "persistance_limit", persistance_limit_)) {
+  if (!ParseVal(node, "k3", k3_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "persistence_limit", persistence_limit_)) {
     return false;
   }
 
@@ -67,8 +70,8 @@ bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
     return false;
   }
 
-  if (signals_.size() < FC_TNTM_NUM_SIGNALS) {
-    ERROR("Expecting at least %d signals for Three Node Thermal Model device",
+  if (signals_.size() != FC_TNTM_NUM_SIGNALS) {
+    ERROR("Expecting exactly %ld signals for Three Node Thermal Model device",
           FC_TNTM_NUM_SIGNALS);
     return false;
   }
@@ -76,7 +79,7 @@ bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
   return true;
 }
 
-bool Read()
+bool ThreeNodeThermalModel::Read()
 {
   // update signals
   for (size_t idx = 0; idx < FC_TNTM_NUM_SIGNALS; idx++) {
@@ -87,22 +90,22 @@ bool Read()
   }
 
   // store them
-  node_3_temp_ =
+  node_temps_[2] =
       signals_[NODE_3_TEMP_IDX].value;  // node 3 temperature is directly taken
                                         // from the signal measurement
   motor_current_ = signals_[MOTOR_CURRENT_IDX].value;
   return true;
 }
 
-FaultType Process()
+FaultType ThreeNodeThermalModel::Process()
 {
-  // TODO
-  // update motor resistance
+  // TODO should there be a check/flag that's monitored for if the model has
+  // been initialized/seeded update motor resistance
   motor_res_ =
       winding_res_ *
       (1 + winding_thermal_cor_ * (node_temps_[0] - REFERENCE_TEMPERATURE));
   // calculate heat transfer rates
-  double q_in = motor_current_ * motor_current_ * motor_res_;
+  double q_in = motor_current_ * motor_current_ * motor_res_;  // I^2 * R
   double q_node_1_to_2 =
       (node_temps_[0] - node_temps_[1]) / thermal_res_nodes_1_to_2_;
   double q_node_2_to_3 =
@@ -114,7 +117,7 @@ FaultType Process()
       (q_node_1_to_2 - q_node_2_to_3) * (loop_period_ / thermal_mass_node_2_);
   node_temps_[3] = (k1_ * node_temps_[0] + k3_ * node_temps_[2]) / (k1_ + k3_);
   // update persistence counter for each node
-  for (size_t idx = 0; idx < node_temps_.size()) {
+  for (size_t idx = 0; idx < node_temps_.size(); ++idx) {
     if (node_temps_[idx] > max_allowable_temps_[idx]) {
       node_overtemp_persistences_[idx]++;
     } else {
@@ -122,23 +125,26 @@ FaultType Process()
     }
     // throw fault if limit exceeded
     if (node_overtemp_persistences_[idx] > persistence_limit_) {
-      ERROR("Node %d temperature exceeded safety limit -- faulting", idx);
+      ERROR("Node %ld temperature exceeded safety limit -- faulting", idx + 1u);
       return ALL_DEVICE_FAULT;
     }
   }
+  state_->three_node_thermal_model_state.node_1_temp = node_temps_[0];
+  state_->three_node_thermal_model_state.node_2_temp = node_temps_[1];
+  state_->three_node_thermal_model_state.node_3_temp = node_temps_[2];
+  state_->three_node_thermal_model_state.node_4_temp = node_temps_[3];
+
   return NO_FAULT;
 }
 
-bool Write(DeviceCmd& cmd)
+bool ThreeNodeThermalModel::Write(DeviceCmd& cmd)
 {
-  // TODO
   if (cmd.type == SEED_THERMAL_MODEL_TEMPERATURE_CMD) {
-    for (size_t idx = 0; idx < node_temps_.size()) {
-      node_temps_[idx] = cmd.seed_thermal_model_temperature.seed_temperature;
+    for (size_t idx = 0; idx < node_temps_.size(); ++idx) {
+      node_temps_[idx] =
+          cmd.seed_thermal_model_temperature_cmd.seed_temperature;
     }
   }
   return true;
 }
-
-// TODO: add function/action to seed temperature
 }  // namespace fastcat

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -17,9 +17,9 @@ namespace fastcat
 static constexpr size_t FC_TNTM_NUM_SIGNALS =
     2;  // the required number of signals for this device
 static constexpr size_t NODE_3_TEMP_IDX =
-    2;  // signal index for node 3 temperature
+    0;  // signal index for node 3 temperature
 static constexpr size_t MOTOR_CURRENT_IDX =
-    2;  // signal index for motor current
+    1;  // signal index for motor current
 static constexpr double REFERENCE_TEMPERATURE =
     20.0;  // reference temperature for calculations
 
@@ -57,7 +57,8 @@ class ThreeNodeThermalModel : public DeviceBase
 
   /**
    * @brief Commands device
-   *        TODO: describe the available commands
+   *        Currently, only the SEED_THERMAL_MODEL_TEMPERATURE_CMD, used to
+   * reseed the model is accepted
    * @param cmd Command provided to the device, of a type that is a subclass of
    * DeviceCmd
    * @return boolean for if the command was accepted and successful or not
@@ -78,9 +79,9 @@ class ThreeNodeThermalModel : public DeviceBase
 
   // declare fault protection parameters
   std::vector<double> max_allowable_temps_{0.0, 0.0, 0.0, 0.0};
-  size_t              persistence_limit_{
+  uint32_t            persistence_limit_{
       0};  ///< represents how many time cycles a temperature limit is able to
-                        ///< be exceeded before throwing a fault
+                      ///< be exceeded before throwing a fault
 
   // declare variables for storing signal data and estimates
   double motor_current_{

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -25,7 +25,7 @@ class ThreeNodeThermalModel : public DeviceBase
 
   /**
    * @brief Parses input yaml file to set model constants and temperature
-   * limits.
+   *        limits.
    * @param node The portion of the yaml file corresponding to this device.
    * @return True if configuration completes without error; false otherwise.
    */
@@ -56,7 +56,34 @@ class ThreeNodeThermalModel : public DeviceBase
   bool Write(DeviceCmd& cmd) override;
 
  protected:
-  // TODO: add constants and variables parsed from config
+  // declare motor parameters
+  double thermal_mass_node_1_{0.0};
+  double thermal_mass_node_2_{0.0};
+  double thermal_resistance_nodes_1_to_2_{0.0};
+  double thermal_resistance_nodes_2_to_3_{0.0};
+  double winding_resistance_{0.0};
+  double winding_thermal_cor_{0.0};  /// coefficient of resistance
+  double motor_resistance_{0.0};
+  double k1_{0.0}, k3_{0.0};  /// weights for T4 estimate
+
+  // declare fault protection parameters
+  double max_allowable_temp_1_{0.0};
+  double max_allowable_temp_2_{0.0};
+  double max_allowable_temp_3_{0.0};
+  double max_allowable_temp_4_{0.0};
+  size_t persistance_limit_{0};
+
+  // declare variables for storing signal data and estimates
+  double motor_current_{
+      0.0};  ///< this value is retrieved from a motor controller measurement
+  double node_1_temp_{0.0};  ///< this value is estimated from the model and
+                             ///< represents winding temperature
+  double node_2_temp_{0.0};  ///< this value is estimated from the model and
+                             ///< represents stator temperature
+  double node_3_temp_{0.0};  ///< this value is measured directly using a sensor
+  double node_4_temp_{
+      0.0};  ///< this value is estimated from the model and generally
+             ///< represents all other component temperatures
 };
 }  // namespace fastcat
 

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -14,6 +14,15 @@
 
 namespace fastcat
 {
+static constexpr size_t FC_TNTM_NUM_SIGNALS =
+    2;  // the required number of signals for this device
+static constexpr size_t NODE_3_TEMP_IDX =
+    2;  // signal index for node 3 temperature
+static constexpr size_t MOTOR_CURRENT_IDX =
+    2;  // signal index for motor current
+static constexpr double REFERENCE_TEMPERATURE =
+    20.0;  // reference temperature for calculations
+
 /**
  * @brief Class implementing a Three-Node Thermal Model for estimating
  *         internal motor temperatures, through fastcat.
@@ -59,7 +68,8 @@ class ThreeNodeThermalModel : public DeviceBase
   // declare motor parameters
   double thermal_mass_node_1_{0.0};
   double thermal_mass_node_2_{0.0};
-  double{0.0};  ///< thermal resistance from node 1 to 2 (deg C / W)
+  double thermal_res_nodes_1_to_2_{
+      0.0};  ///< thermal resistance from node 1 to 2 (deg C / W)
   double thermal_res_nodes_2_to_3_{
       0.0};  ///< thermal resistance from node 2 to 3 (deg C / W)
   double winding_res_{0.0};  ///< motor winding electrical resistance (ohms)
@@ -68,24 +78,22 @@ class ThreeNodeThermalModel : public DeviceBase
 
   // declare fault protection parameters
   std::vector<double> max_allowable_temps_{0.0, 0.0, 0.0, 0.0};
-  size_t persistance_limit_{
+  size_t              persistence_limit_{
       0};  ///< represents how many time cycles a temperature limit is able to
-           ///< be exceeded before throwing a fault
+                        ///< be exceeded before throwing a fault
 
   // declare variables for storing signal data and estimates
   double motor_current_{
       0.0};  ///< this value is retrieved from a motor controller measurement
-  double motor_resistance_{
-      0.0};  ///< this value is estimated based on the temp 1 estimate and
-             ///< represents the resistance of the motor, which is used for
-             ///< calculated power
-  double node_1_temp_{0.0};  ///< this value is estimated from the model and
-                             ///< represents winding temperature
-  double node_2_temp_{0.0};  ///< this value is estimated from the model and
-                             ///< represents stator temperature
-  double node_3_temp_{0.0};  ///< this value is measured directly using a sensor
-  double node_4_temp_{0.0};  ///< this value is estimated from the model and
-                             ///< represents all other component temperatures
+  double motor_res_{0.0};  ///< this value is estimated based on the temp 1
+                           ///< estimate and represents the resistance of the
+                           ///< motor, which is used for calculated power
+  std::vector<double> node_temps_{
+      0.0, 0.0, 0.0, 0.0};  ///< this value is estimated from the model and
+                            ///< represents winding temperature
+  std::vector<size_t> node_overtemp_persistences_{
+      0, 0, 0, 0};  ///< this is used as a counter for how many cycles node 1
+                    ///< has been over the temperature limit
 };
 }  // namespace fastcat
 

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -59,23 +59,30 @@ class ThreeNodeThermalModel : public DeviceBase
   // declare motor parameters
   double thermal_mass_node_1_{0.0};
   double thermal_mass_node_2_{0.0};
-  double thermal_resistance_nodes_1_to_2_{0.0};
-  double thermal_resistance_nodes_2_to_3_{0.0};
-  double winding_resistance_{0.0};
-  double winding_thermal_cor_{0.0};  /// coefficient of resistance
-  double motor_resistance_{0.0};
-  double k1_{0.0}, k3_{0.0};  /// weights for T4 estimate
+  double thermal_res_nodes_1_to_2_{
+      0.0};  ///< thermal resistance from node 1 to 2 (deg C / W)
+  double thermal_res_nodes_2_to_3_{
+      0.0};  ///< thermal resistance from node 2 to 3 (deg C / W)
+  double winding_res_{0.0};  ///< motor winding electrical resistance (ohms)
+  double winding_thermal_cor_{0.0};  ///< coefficient of resistance
+  double k1_{0.0}, k3_{0.0};         ///< weights for T4 estimate
 
   // declare fault protection parameters
   double max_allowable_temp_1_{0.0};
   double max_allowable_temp_2_{0.0};
   double max_allowable_temp_3_{0.0};
   double max_allowable_temp_4_{0.0};
-  size_t persistance_limit_{0};
+  size_t persistance_limit_{
+      0};  ///< represents how many time cycles a temperature limit is able to
+           ///< be exceeded before throwing a fault
 
   // declare variables for storing signal data and estimates
   double motor_current_{
       0.0};  ///< this value is retrieved from a motor controller measurement
+  double motor_resistance_{
+      0.0};  ///< this value is estimated based on the temp 1 estimate and
+             ///< represents the resistance of the motor, which is used for
+             ///< calculated power
   double node_1_temp_{0.0};  ///< this value is estimated from the model and
                              ///< represents winding temperature
   double node_2_temp_{0.0};  ///< this value is estimated from the model and

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -84,9 +84,8 @@ class ThreeNodeThermalModel : public DeviceBase
   double node_2_temp_{0.0};  ///< this value is estimated from the model and
                              ///< represents stator temperature
   double node_3_temp_{0.0};  ///< this value is measured directly using a sensor
-  double node_4_temp_{
-      0.0};  ///< this value is estimated from the model and generally
-             ///< represents all other component temperatures
+  double node_4_temp_{0.0};  ///< this value is estimated from the model and
+                             ///< represents all other component temperatures
 };
 }  // namespace fastcat
 

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -1,0 +1,63 @@
+#ifndef FASTCAT_THREE_NODE_THERMAL_MODEL_H_
+#define FASTCAT_THREE_NODE_THERMAL_MODEL_H_
+
+// Include external then project includes
+#include "fastcat/device_base.h"
+
+// Include c then c++ libraries
+#include <cmath>
+
+// Include external then project includes
+#include "fastcat/signal_handling.h"
+#include "fastcat/yaml_parser.h"
+#include "jsd/jsd_print.h"
+
+namespace fastcat
+{
+/**
+ * @brief Class implementing a Three-Node Thermal Model for estimating
+ *         internal motor temperatures, through fastcat.
+ */
+class ThreeNodeThermalModel : public DeviceBase
+{
+ public:
+  ThreeNodeThermalModel();  ///< ThreeNodeThermalModel constructor.
+
+  /**
+   * @brief Parses input yaml file to set model constants and temperature
+   * limits.
+   * @param node The portion of the yaml file corresponding to this device.
+   * @return True if configuration completes without error; false otherwise.
+   */
+  bool ConfigFromYaml(YAML::Node node) override;
+
+  /**
+   * @brief Reads in most recent temperature and current signal values, and
+   *        stores them for further calculations.
+   * @return True if device state is read without error; false otherwise.
+   */
+  bool Read() override;
+
+  /**
+   * @brief Performs one update step of the thermal prediction model, tracking
+   *        the most recently predicted temperature values at each node, and
+   *        reporting a fault if any of the limits are exceeded
+   * @return FaultType enum value corresponding to appropriate fault state.
+   */
+  FaultType Process() override;
+
+  /**
+   * @brief Commands device
+   *        TODO: describe the available commands
+   * @param cmd Command provided to the device, of a type that is a subclass of
+   * DeviceCmd
+   * @return boolean for if the command was accepted and successful or not
+   */
+  bool Write(DeviceCmd& cmd) override;
+
+ protected:
+  // TODO: add constants and variables parsed from config
+};
+}  // namespace fastcat
+
+#endif

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -59,8 +59,7 @@ class ThreeNodeThermalModel : public DeviceBase
   // declare motor parameters
   double thermal_mass_node_1_{0.0};
   double thermal_mass_node_2_{0.0};
-  double thermal_res_nodes_1_to_2_{
-      0.0};  ///< thermal resistance from node 1 to 2 (deg C / W)
+  double{0.0};  ///< thermal resistance from node 1 to 2 (deg C / W)
   double thermal_res_nodes_2_to_3_{
       0.0};  ///< thermal resistance from node 2 to 3 (deg C / W)
   double winding_res_{0.0};  ///< motor winding electrical resistance (ohms)
@@ -68,10 +67,7 @@ class ThreeNodeThermalModel : public DeviceBase
   double k1_{0.0}, k3_{0.0};         ///< weights for T4 estimate
 
   // declare fault protection parameters
-  double max_allowable_temp_1_{0.0};
-  double max_allowable_temp_2_{0.0};
-  double max_allowable_temp_3_{0.0};
-  double max_allowable_temp_4_{0.0};
+  std::vector<double> max_allowable_temps_{0.0, 0.0, 0.0, 0.0};
   size_t persistance_limit_{
       0};  ///< represents how many time cycles a temperature limit is able to
            ///< be exceeded before throwing a fault

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -768,3 +768,9 @@ commands:
       type: jsd_sdo_data_type_t
     - name: app_id
       type: uint16_t
+
+  - name: three_node_thermal_model
+    fields:
+    - name: fault_active
+      type: bool
+      comment: "if true, the temperature conditions predicted for faulting have been exceeded"

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -433,6 +433,12 @@ states:
     - name: brake_cc_val
       type: uint16_t
 
+- name: three_node_thermal_model
+    fields:
+    - name: fault_active
+      type: bool
+      comment: "if true, the temperature conditions predicted for faulting have been exceeded"
+
 commands:
   - name: commander_enable
     fields:
@@ -769,8 +775,9 @@ commands:
     - name: app_id
       type: uint16_t
 
-  - name: three_node_thermal_model
+  - name: seed_thermal_model_temperature
+    comment: "command to reseed the temperatures, uniformly, of the nodes in a three node thermal model"
     fields:
-    - name: fault_active
-      type: bool
-      comment: "if true, the temperature conditions predicted for faulting have been exceeded"
+    - name: seed_temperature
+      type: double
+      

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -433,11 +433,23 @@ states:
     - name: brake_cc_val
       type: uint16_t
 
-- name: three_node_thermal_model
+  - name: three_node_thermal_model
     fields:
     - name: fault_active
       type: bool
       comment: "if true, the temperature conditions predicted for faulting have been exceeded"
+    - name: node_1_temp
+      type: double
+      comment: "temperature estimate of node 1" 
+    - name: node_2_temp
+      type: double
+      comment: "temperature estimate of node 2" 
+    - name: node_3_temp
+      type: double
+      comment: "temperature estimate of node 3" 
+    - name: node_4_temp
+      type: double
+      comment: "temperature estimate of node 4" 
 
 commands:
   - name: commander_enable

--- a/test/test_unit/CMakeLists.txt
+++ b/test/test_unit/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     test_fts.cc
     test_ati_fts.cc
     test_virtual_fts.cc
+    test_three_node_thermal_model.cc
     )
 
 foreach(TEST_SOURCE ${TEST_SOURCES})

--- a/test/test_unit/test_three_node_thermal_model.cc
+++ b/test/test_unit/test_three_node_thermal_model.cc
@@ -1,0 +1,179 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "fastcat/config.h"
+#include "fastcat/fastcat_devices/three_node_thermal_model.h"
+#include "fastcat/signal_handling.h"
+#include "jsd/jsd_print.h"
+
+static constexpr double DOUBLE_COMP_THRESHOLD = 1e-10;
+
+class ThreeNodeThermalModelTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    base_dir_ = FASTCAT_UNIT_TEST_DIR;
+    base_dir_ += "test_three_node_thermal_model_yamls/";
+    device_.SetLoopPeriod(1.0);
+  }
+
+  std::string                    base_dir_;
+  YAML::Node                     node_;
+  fastcat::ThreeNodeThermalModel device_;
+};
+
+TEST_F(ThreeNodeThermalModelTest, SetupValid)
+{
+  node_ = YAML::LoadFile(base_dir_ + "valid.yaml");
+  EXPECT_TRUE(device_.ConfigFromYaml(node_));
+}
+
+TEST_F(ThreeNodeThermalModelTest, BadConfigNumSignals)
+{
+  node_ = YAML::LoadFile(base_dir_ + "invalid_num_signals.yaml");
+  EXPECT_FALSE(device_.ConfigFromYaml(node_));
+}
+
+TEST_F(ThreeNodeThermalModelTest, BadConfigNumTemps)
+{
+  node_ = YAML::LoadFile(base_dir_ + "invalid_num_temps.yaml");
+  EXPECT_FALSE(device_.ConfigFromYaml(node_));
+}
+
+TEST_F(ThreeNodeThermalModelTest, SeedTemp)
+{  // init device
+  node_ = YAML::LoadFile(base_dir_ + "valid.yaml");
+  EXPECT_TRUE(device_.ConfigFromYaml(node_));
+  // check initial state outputs
+  auto state = device_.GetState();
+
+  // inputs
+  double* node_3_temp_input   = &device_.signals_[0].value;
+  double* motor_current_input = &device_.signals_[1].value;
+
+  // outputs
+  double* node_1_temp_output =
+      &state->three_node_thermal_model_state.node_1_temp;
+  double* node_2_temp_output =
+      &state->three_node_thermal_model_state.node_2_temp;
+  double* node_3_temp_output =
+      &state->three_node_thermal_model_state.node_3_temp;
+  double* node_4_temp_output =
+      &state->three_node_thermal_model_state.node_4_temp;
+
+  EXPECT_NEAR(*node_1_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+
+  fastcat::DeviceCmd cmd;
+  cmd.type = fastcat::SEED_THERMAL_MODEL_TEMPERATURE_CMD;
+  cmd.seed_thermal_model_temperature_cmd.seed_temperature = 20.0;
+  EXPECT_TRUE(device_.Write(cmd));
+  *node_3_temp_input   = 20.0;
+  *motor_current_input = 0.0;
+  EXPECT_TRUE(device_.Read());
+  EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
+  EXPECT_NEAR(*node_1_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+}
+
+TEST_F(ThreeNodeThermalModelTest, CurrentInput)
+{
+  // init device
+  node_ = YAML::LoadFile(base_dir_ + "valid.yaml");
+  EXPECT_TRUE(device_.ConfigFromYaml(node_));
+  // check initial state outputs
+  auto state = device_.GetState();
+
+  // inputs
+  double* node_3_temp_input   = &device_.signals_[0].value;
+  double* motor_current_input = &device_.signals_[1].value;
+
+  // outputs
+  double* node_1_temp_output =
+      &state->three_node_thermal_model_state.node_1_temp;
+  double* node_2_temp_output =
+      &state->three_node_thermal_model_state.node_2_temp;
+  double* node_3_temp_output =
+      &state->three_node_thermal_model_state.node_3_temp;
+  double* node_4_temp_output =
+      &state->three_node_thermal_model_state.node_4_temp;
+
+  EXPECT_NEAR(*node_1_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+
+  fastcat::DeviceCmd cmd;
+  cmd.type = fastcat::SEED_THERMAL_MODEL_TEMPERATURE_CMD;
+  cmd.seed_thermal_model_temperature_cmd.seed_temperature = 20.0;
+  EXPECT_TRUE(device_.Write(cmd));
+  *node_3_temp_input   = 20.0;
+  *motor_current_input = 1.0;
+  EXPECT_TRUE(device_.Read());
+  EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
+  EXPECT_NEAR(*node_1_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 20.5, DOUBLE_COMP_THRESHOLD);
+  EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
+  EXPECT_NEAR(*node_1_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 20.5, DOUBLE_COMP_THRESHOLD);
+  EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
+  EXPECT_NEAR(*node_1_temp_output, 22.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
+  EXPECT_NEAR(*node_1_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 22.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 20.5, DOUBLE_COMP_THRESHOLD);
+}
+
+TEST_F(ThreeNodeThermalModelTest, TempFault)
+{
+  // init device
+  node_ = YAML::LoadFile(base_dir_ + "valid.yaml");
+  EXPECT_TRUE(device_.ConfigFromYaml(node_));
+  // check initial state outputs
+  auto state = device_.GetState();
+
+  // inputs
+  double* node_3_temp_input   = &device_.signals_[0].value;
+  double* motor_current_input = &device_.signals_[1].value;
+
+  // outputs
+  double* node_1_temp_output =
+      &state->three_node_thermal_model_state.node_1_temp;
+  double* node_2_temp_output =
+      &state->three_node_thermal_model_state.node_2_temp;
+  double* node_3_temp_output =
+      &state->three_node_thermal_model_state.node_3_temp;
+  double* node_4_temp_output =
+      &state->three_node_thermal_model_state.node_4_temp;
+
+  EXPECT_NEAR(*node_1_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_2_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_3_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+  EXPECT_NEAR(*node_4_temp_output, 0.0, DOUBLE_COMP_THRESHOLD);
+
+  fastcat::DeviceCmd cmd;
+  cmd.type = fastcat::SEED_THERMAL_MODEL_TEMPERATURE_CMD;
+  cmd.seed_thermal_model_temperature_cmd.seed_temperature = 20.0;
+  EXPECT_TRUE(device_.Write(cmd));
+  *node_3_temp_input   = 20.0;
+  *motor_current_input = 100.0;
+  EXPECT_TRUE(device_.Read());
+  EXPECT_EQ(device_.Process(),
+            fastcat::NO_FAULT);  // config allows one cycle of persistance
+                                 // before faulting
+  EXPECT_EQ(device_.Process(), fastcat::ALL_DEVICE_FAULT);
+}

--- a/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_signals.yaml
+++ b/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_signals.yaml
@@ -1,0 +1,19 @@
+device_class: ThreeNodeThermalModel
+name:         three_node_thermal_model_1 
+thermal_mass_node_1: 1.0
+thermal_mass_node_2: 2.0
+thermal_res_nodes_1_to_2: 3.0
+thermal_res_nodes_2_to_3: 4.0
+winding_res: 5.0
+winding_thermal_cor: 6.0
+k1: 1.0
+k3: 2.0
+persistence_limit: 5
+max_allowable_temps: [65.0, 70.0, 75.0, 80.0]
+signals:
+- observed_device_name: el3602
+  request_signal_name:  voltage_ch1
+- observed_device_name: egd_1
+  request_signal_name:  actual_current
+- observed_device_name: egd_2
+  request_signal_name:  actual_current

--- a/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_temps.yaml
+++ b/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_temps.yaml
@@ -1,0 +1,17 @@
+device_class: ThreeNodeThermalModel
+name:         three_node_thermal_model_1 
+thermal_mass_node_1: 1.0
+thermal_mass_node_2: 2.0
+thermal_res_nodes_1_to_2: 3.0
+thermal_res_nodes_2_to_3: 4.0
+winding_res: 5.0
+winding_thermal_cor: 6.0
+k1: 1.0
+k3: 2.0
+persistence_limit: 5
+max_allowable_temps: [65.0, 70.0, 75.0, 80.0, 100.0]
+signals:
+- observed_device_name: el3602
+  request_signal_name:  voltage_ch1
+- observed_device_name: egd_1
+  request_signal_name:  actual_current

--- a/test/test_unit/test_three_node_thermal_model_yamls/valid.yaml
+++ b/test/test_unit/test_three_node_thermal_model_yamls/valid.yaml
@@ -1,0 +1,17 @@
+device_class: ThreeNodeThermalModel
+name:         three_node_thermal_model_1 
+thermal_mass_node_1: 1.0
+thermal_mass_node_2: 1.0
+thermal_res_nodes_1_to_2: 1.0
+thermal_res_nodes_2_to_3: 1.0
+winding_res: 1.0
+winding_thermal_cor: 0.0
+k1: 1.0
+k3: 1.0
+persistence_limit: 1
+max_allowable_temps: [100.0, 100.0, 100.0, 100.0]
+signals:
+- observed_device_name: FIXED_VALUE
+  fixed_value:          20 
+- observed_device_name: FIXED_VALUE
+  fixed_value:          1.0 


### PR DESCRIPTION
# What is it?
* adds a new fastcat device that represents a three node thermal model
    * this device gives low-fidelity estimates of motor internal temperature values, utilized to prevent damage to hardware caused by overheating
    * includes unit tests and example configuration files

# How do I use it?
* specify the needed parameters to represent your actuator setup in a fastcat yaml file, and connect to other devices to monitor temperature values and fault conditions

# Note/Future Work/Open Questions
* implement more robust temperature seeding -- seed at the beginning using either FIXED_VALUE or PRT readings and allow for reseeding if commanded
* expand unit test cases