### PR TITLE
Prefix trap functions with fastcat to support composition

### DIFF
--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -134,7 +134,7 @@ class Actuator : public JsdDeviceBase
   ActuatorStateMachineState actuator_sms_;
   double                    last_transition_time_ = 0.0;
   double                    cycle_mono_time_      = 0.0;
-  trap_t                    trap_;
+  fastcat_trap_t            trap_;
   ActuatorParams            params_;
 
   ActuatorFastcatFault fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_OKAY;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -428,7 +428,7 @@ bool fastcat::Actuator::HandleNewCalibrationCmd(const DeviceCmd& cmd)
   MSG("Setting Peak Current to calibration level: %lf", cal_cmd_.max_current);
   ElmoSetPeakCurrent(cal_cmd_.max_current);
 
-  trap_generate(&trap_, state_->time,
+  fastcat_trap_generate(&trap_, state_->time,
                 GetActualPosition(*state_),  // consider cmd position
                 target_position,
                 GetActualVelocity(),  // consider cmd velocity
@@ -517,7 +517,7 @@ fastcat::FaultType fastcat::Actuator::ProcessProfPosTrapImpl()
   jsd_elmo_motion_command_csp_t jsd_cmd;
 
   double pos_eu, vel;
-  int    complete = trap_update(&trap_, state_->time, &pos_eu, &vel);
+  int    complete = fastcat_trap_update(&trap_, state_->time, &pos_eu, &vel);
 
   jsd_cmd.target_position    = PosEuToCnts(pos_eu);
   jsd_cmd.position_offset    = 0;
@@ -578,7 +578,7 @@ fastcat::FaultType fastcat::Actuator::ProcessCalMoveToHardstop()
   jsd_elmo_motion_command_csp_t jsd_cmd;
 
   double pos_eu, vel;
-  int    complete = trap_update(&trap_, state_->time, &pos_eu, &vel);
+  int    complete = fastcat_trap_update(&trap_, state_->time, &pos_eu, &vel);
 
   jsd_cmd.target_position    = PosEuToCnts(pos_eu);
   jsd_cmd.position_offset    = 0;
@@ -637,7 +637,7 @@ fastcat::FaultType fastcat::Actuator::ProcessCalAtHardstop()
   }
   SetOutputPosition(cal_position);
 
-  trap_generate(&trap_, state_->time, cal_position, backoff_position, 0,
+  fastcat_trap_generate(&trap_, state_->time, cal_position, backoff_position, 0,
                 0,  // pt2pt motion always uses terminating traps
                 fabs(cal_cmd_.velocity), cal_cmd_.accel);
 

--- a/src/jsd/gold_actuator.cc
+++ b/src/jsd/gold_actuator.cc
@@ -190,7 +190,7 @@ bool fastcat::GoldActuator::HandleNewProfPosCmdImpl(const DeviceCmd& cmd)
     return true;
   }
 
-  trap_generate(
+  fastcat_trap_generate(
       &trap_, state_->time, state_->gold_actuator_state.actual_position,
       ComputeTargetPosProfPosCmd(cmd), state_->gold_actuator_state.cmd_velocity,
       cmd.actuator_prof_pos_cmd.end_velocity,
@@ -212,7 +212,7 @@ bool fastcat::GoldActuator::HandleNewProfVelCmdImpl(const DeviceCmd& cmd)
     return true;
   }
 
-  trap_generate_vel(&trap_, state_->time,
+  fastcat_trap_generate_vel(&trap_, state_->time,
                     state_->gold_actuator_state.actual_position,
                     state_->gold_actuator_state.cmd_velocity,
                     cmd.actuator_prof_vel_cmd.target_velocity,
@@ -234,7 +234,7 @@ bool fastcat::GoldActuator::HandleNewProfTorqueCmdImpl(const DeviceCmd& cmd)
     return true;
   }
 
-  trap_generate_vel(&trap_, state_->time, 0, 0,
+  fastcat_trap_generate_vel(&trap_, state_->time, 0, 0,
                     cmd.actuator_prof_torque_cmd.target_torque_amps,
                     params_.torque_slope_amps_per_sec,
                     cmd.actuator_prof_torque_cmd.max_duration);
@@ -259,7 +259,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfVel()
   jsd_elmo_motion_command_csv_t jsd_cmd;
 
   double pos_eu, vel;
-  int    complete = trap_update_vel(&trap_, state_->time, &pos_eu, &vel);
+  int    complete = fastcat_trap_update_vel(&trap_, state_->time, &pos_eu, &vel);
 
   jsd_cmd.target_velocity    = EuToCnts(vel);
   jsd_cmd.velocity_offset    = 0;
@@ -285,7 +285,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfTorque()
   jsd_elmo_motion_command_cst_t jsd_cmd;
 
   double dummy_pos_eu, current;
-  int complete = trap_update_vel(&trap_, state_->time, &dummy_pos_eu, &current);
+  int complete = fastcat_trap_update_vel(&trap_, state_->time, &dummy_pos_eu, &current);
 
   jsd_cmd.target_torque_amps = current;
   jsd_cmd.torque_offset_amps = 0;
@@ -308,7 +308,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfPosDisengaging()
   if (state_->gold_actuator_state.servo_enabled) {
     // If brakes are disengaged, setup the traps and transition to the execution
     // state
-    trap_generate(
+    fastcat_trap_generate(
         &trap_, state_->time, state_->gold_actuator_state.actual_position,
         ComputeTargetPosProfPosCmd(last_cmd_),
         state_->gold_actuator_state.cmd_velocity,
@@ -355,7 +355,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfVelDisengaging()
   if (state_->gold_actuator_state.servo_enabled) {
     // If brakes are disengaged, setup the traps and transition to the execution
     // state
-    trap_generate_vel(&trap_, state_->time,
+    fastcat_trap_generate_vel(&trap_, state_->time,
                       state_->gold_actuator_state.actual_position,
                       state_->gold_actuator_state.cmd_velocity,
                       last_cmd_.actuator_prof_vel_cmd.target_velocity,
@@ -398,7 +398,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfTorqueDisengaging()
   if (state_->gold_actuator_state.servo_enabled) {
     // If brakes are disengaged, setup the traps and transition to the execution
     // state
-    trap_generate_vel(&trap_, state_->time, 0, 0,
+    fastcat_trap_generate_vel(&trap_, state_->time, 0, 0,
                       last_cmd_.actuator_prof_torque_cmd.target_torque_amps,
                       params_.torque_slope_amps_per_sec,
                       last_cmd_.actuator_prof_torque_cmd.max_duration);

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -28,7 +28,7 @@ bool fastcat::PlatinumActuatorOffline::HandleNewProfPosCmdImpl(const DeviceCmd& 
     return true;
   }
 
-  trap_generate(
+  fastcat_trap_generate(
       &trap_, state_->time, state_->platinum_actuator_state.actual_position,
       ComputeTargetPosProfPosCmd(cmd), state_->platinum_actuator_state.cmd_velocity,
       cmd.actuator_prof_pos_cmd.end_velocity,
@@ -50,7 +50,7 @@ bool fastcat::PlatinumActuatorOffline::HandleNewProfVelCmdImpl(const DeviceCmd& 
     return true;
   }
 
-  trap_generate_vel(&trap_, state_->time,
+  fastcat_trap_generate_vel(&trap_, state_->time,
                     state_->platinum_actuator_state.actual_position,
                     state_->platinum_actuator_state.cmd_velocity,
                     cmd.actuator_prof_vel_cmd.target_velocity,
@@ -73,7 +73,7 @@ bool fastcat::PlatinumActuatorOffline::HandleNewProfTorqueCmdImpl(
     return true;
   }
 
-  trap_generate_vel(&trap_, state_->time, 0, 0,
+  fastcat_trap_generate_vel(&trap_, state_->time, 0, 0,
                     cmd.actuator_prof_torque_cmd.target_torque_amps,
                     params_.torque_slope_amps_per_sec,
                     cmd.actuator_prof_torque_cmd.max_duration);
@@ -98,7 +98,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfVel()
   jsd_elmo_motion_command_csv_t jsd_cmd;
 
   double pos_eu, vel;
-  int    complete = trap_update_vel(&trap_, state_->time, &pos_eu, &vel);
+  int    complete = fastcat_trap_update_vel(&trap_, state_->time, &pos_eu, &vel);
 
   jsd_cmd.target_velocity    = EuToCnts(vel);
   jsd_cmd.velocity_offset    = 0;
@@ -124,7 +124,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfTorque()
   jsd_elmo_motion_command_cst_t jsd_cmd;
 
   double dummy_pos_eu, current;
-  int complete = trap_update_vel(&trap_, state_->time, &dummy_pos_eu, &current);
+  int complete = fastcat_trap_update_vel(&trap_, state_->time, &dummy_pos_eu, &current);
 
   jsd_cmd.target_torque_amps = current;
   jsd_cmd.torque_offset_amps = 0;
@@ -147,7 +147,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfPosDisengaging()
   if (state_->platinum_actuator_state.servo_enabled) {
     // If brakes are disengaged, setup the traps and transition to the execution
     // state
-    trap_generate(
+    fastcat_trap_generate(
         &trap_, state_->time, state_->platinum_actuator_state.actual_position,
         ComputeTargetPosProfPosCmd(last_cmd_),
         state_->platinum_actuator_state.cmd_velocity,
@@ -194,7 +194,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfVelDisengaging()
   if (state_->platinum_actuator_state.servo_enabled) {
     // If brakes are disengaged, setup the traps and transition to the execution
     // state
-    trap_generate_vel(&trap_, state_->time,
+    fastcat_trap_generate_vel(&trap_, state_->time,
                       state_->platinum_actuator_state.actual_position,
                       state_->platinum_actuator_state.cmd_velocity,
                       last_cmd_.actuator_prof_vel_cmd.target_velocity,
@@ -237,7 +237,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfTorqueDisengagin
   if (state_->platinum_actuator_state.servo_enabled) {
     // If brakes are disengaged, setup the traps and transition to the execution
     // state
-    trap_generate_vel(&trap_, state_->time, 0, 0,
+    fastcat_trap_generate_vel(&trap_, state_->time, 0, 0,
                       last_cmd_.actuator_prof_torque_cmd.target_torque_amps,
                       params_.torque_slope_amps_per_sec,
                       last_cmd_.actuator_prof_torque_cmd.max_duration);

--- a/src/trap.c
+++ b/src/trap.c
@@ -104,7 +104,7 @@ static bool profile_is_a_negative_ramp(double vel_start, double vel_max,
  * @param  acc        max acceleration/deceleration for the profile
  * @return            0 on success, -1 on failure
  */
-int trap_generate(trap_t* self, double t_init_sec, double pos_init,
+int fastcat_trap_generate(fastcat_trap_t* self, double t_init_sec, double pos_init,
                   double pos_fini, double vel_init, double vel_fini,
                   double vel_max, double acc)
 {
@@ -384,12 +384,12 @@ int trap_generate(trap_t* self, double t_init_sec, double pos_init,
   self->vel_pre  = vi;
   self->vel_acc  = vm;
 
-  self->mode = TRAP_MODE_POS;
+  self->mode = FASTCAT_TRAP_MODE_POS;
 
   return 0;
 }
 
-int trap_update(trap_t* self, double t, double* pos, double* vel)
+int fastcat_trap_update(fastcat_trap_t* self, double t, double* pos, double* vel)
 {
   double dt;
 
@@ -406,7 +406,7 @@ int trap_update(trap_t* self, double t, double* pos, double* vel)
     *vel = self->vel_fini;
 
     // if the profile has expired, report this back
-    self->mode = TRAP_MODE_IDLE;
+    self->mode = FASTCAT_TRAP_MODE_IDLE;
     return 1;
   } else if (t < self->t_pre) {
     //
@@ -433,7 +433,7 @@ int trap_update(trap_t* self, double t, double* pos, double* vel)
   return 0;
 }
 
-int trap_generate_vel(trap_t* self, double t_init_sec, double pos_init,
+int fastcat_trap_generate_vel(fastcat_trap_t* self, double t_init_sec, double pos_init,
                       double vel_init, double vel_fini, double acc,
                       double max_time)
 {
@@ -478,12 +478,12 @@ int trap_generate_vel(trap_t* self, double t_init_sec, double pos_init,
   self->pos_fini =
       self->pos_dec + self->vel_acc * dt + 0.5 * self->dec * dt * dt;
 
-  self->mode = TRAP_MODE_RATE;
+  self->mode = FASTCAT_TRAP_MODE_RATE;
 
   return 0;
 }
 
-int trap_update_vel(trap_t* self, double t, double* pos, double* vel)
+int fastcat_trap_update_vel(fastcat_trap_t* self, double t, double* pos, double* vel)
 {
   double dt;
 
@@ -509,7 +509,7 @@ int trap_update_vel(trap_t* self, double t, double* pos, double* vel)
       {
         *vel       = 0.0;
         *pos       = self->pos_fini;
-        self->mode = TRAP_MODE_IDLE;
+        self->mode = FASTCAT_TRAP_MODE_IDLE;
         return 1;
       }
     } else  // no max time, spinning at v_acc until directed to change...
@@ -523,7 +523,7 @@ int trap_update_vel(trap_t* self, double t, double* pos, double* vel)
   return 0;
 }
 
-void trap_print_trap_values(trap_t* self)
+void fastcat_trap_print_fastcat_trap_values(fastcat_trap_t* self)
 {
   MSG("Position: ini: %f, pre: %f, acc: %f, dec: %f, fin: %f", self->pos_init,
       self->pos_pre, self->pos_acc, self->pos_dec, self->pos_fini);

--- a/src/trap.h
+++ b/src/trap.h
@@ -1,5 +1,5 @@
-#ifndef FASTCAT_TRAP_H_
-#define FASTCAT_TRAP_H_
+#ifndef FASTCAT_FASTCAT_TRAP_H_
+#define FASTCAT_FASTCAT_TRAP_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -8,10 +8,10 @@ extern "C" {
 #include <stdint.h>
 
 typedef enum {
-  TRAP_MODE_IDLE = 0,
-  TRAP_MODE_RATE,
-  TRAP_MODE_POS,
-} trap_mode_t;
+  FASTCAT_TRAP_MODE_IDLE = 0,
+  FASTCAT_TRAP_MODE_RATE,
+  FASTCAT_TRAP_MODE_POS,
+} fastcat_trap_mode_t;
 
 typedef struct {
   double pos_init;  //!< absolute position of the start of the trajectory
@@ -42,18 +42,18 @@ typedef struct {
 
   int mode;
 
-} trap_t;
+} fastcat_trap_t;
 
-int trap_generate(trap_t* self, double t_init, double pos_init, double pos_fini,
+int fastcat_trap_generate(fastcat_trap_t* self, double t_init, double pos_init, double pos_fini,
                   double vel_init, double vel_fini, double max_vel, double acc);
 
-int trap_update(trap_t* self, double t, double* pos, double* vel);
+int fastcat_trap_update(fastcat_trap_t* self, double t, double* pos, double* vel);
 
-int trap_generate_vel(trap_t* self, double t_init_sec, double pos_init,
+int fastcat_trap_generate_vel(fastcat_trap_t* self, double t_init_sec, double pos_init,
                       double vel_init, double vel_fini, double acc,
                       double max_time);
 
-int trap_update_vel(trap_t* self, double t, double* pos, double* vel);
+int fastcat_trap_update_vel(fastcat_trap_t* self, double t, double* pos, double* vel);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Avoids name collision when using fastcat as an external library together with the "trap" library. 

This is necessary to support composition of arm and fcat nodes into a single executable.