### PR TITLE
Updates the JSD version to bring in Platinum related changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG v2.3.1
+    GIT_TAG v2.3.2
     )
 FetchContent_MakeAvailable(jsd)
 


### PR DESCRIPTION
Updates JSD version to 2.3.2 so that the fix implemented in JSD to allow communication in networks with Platinum drives and other devices is incorporated into Fastcat.