### PR TITLE
Draft: Update trap unit test to follow new name convention

### DIFF
--- a/test/test_unit/test_trap.cc
+++ b/test/test_unit/test_trap.cc
@@ -9,7 +9,7 @@ class TrapTest : public ::testing::Test
  protected:
   void SetUp() override {}
 
-  trap_t trap_1_;
+  fastcat_trap_t trap_1_;
 };
 
 TEST_F(TrapTest, TrapVelocityReInit)
@@ -22,7 +22,7 @@ TEST_F(TrapTest, TrapVelocityReInit)
   double max_time         = 10.0;
 
   // Generate the first version of the trap
-  trap_generate_vel(&trap_1_, time_initial, position_initial, velocity_initial,
+  fastcat_trap_generate_vel(&trap_1_, time_initial, position_initial, velocity_initial,
                     velocity_final, acceleration, max_time);
 
   double dt = 0.01;
@@ -33,14 +33,14 @@ TEST_F(TrapTest, TrapVelocityReInit)
 
   for (int i = 0; i < 1000; i++) {
     // Update trap before any change in time has occurred
-    trap_update_vel(&trap_1_, tracking_time, &tracking_position,
+    fastcat_trap_update_vel(&trap_1_, tracking_time, &tracking_position,
                     &tracking_velocity);
 
     // Increment time
     tracking_time += dt;
 
     // Regenerate trap to simulate incoming updated setpoint
-    trap_generate_vel(&trap_1_, tracking_time, tracking_position,
+    fastcat_trap_generate_vel(&trap_1_, tracking_time, tracking_position,
                       tracking_velocity, velocity_final, acceleration,
                       max_time);
   }


### PR DESCRIPTION
* Fixes trap unit test to follow new name convention
* Unit test for gold actuator fails on JSD_EGD_PRODUCT_CODE assertion, @d-loret, can you investigate