### PR TITLE
Dwai jsd compile time verbosity level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG 2.3.7
-    GIT_TAG v2.3.6
+    GIT_TAG v2.3.7
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG 2.3.4
+    GIT_TAG 2.3.7
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/src/trap.c
+++ b/src/trap.c
@@ -172,7 +172,7 @@ int fastcat_trap_generate(fastcat_trap_t* self, double t_init_sec, double pos_in
   // Only accept accelerations higher than epsilon since the result would be
   // a very, very long, slow profile.
   if (acc < eps) {
-    (void)ERROR("acc (%.11f) < %.11f", acc, eps);
+    ERROR("acc (%.11f) < %.11f", acc, eps);
     return -1;
   }
 
@@ -210,7 +210,7 @@ int fastcat_trap_generate(fastcat_trap_t* self, double t_init_sec, double pos_in
     t_m = fabs(d_m / vm);  // time = distance / velocity
 
     if (!(t_m >= 0.0)) {
-      (void)ERROR("pf %5.2f, pi %5.2f, d_acc %5.2f, d_dec %5.2f", pf, pi, d_im,
+      ERROR("pf %5.2f, pi %5.2f, d_acc %5.2f, d_dec %5.2f", pf, pi, d_im,
                   d_mf);
     }
 
@@ -218,7 +218,7 @@ int fastcat_trap_generate(fastcat_trap_t* self, double t_init_sec, double pos_in
     // should take out assertion and check return value to avoid losing
     // position, for example
     if (t_m < 0.0) {
-      (void)ERROR("Cruising time is negative. Failing trap. t_m: %f s", t_m);
+      ERROR("Cruising time is negative. Failing trap. t_m: %f s", t_m);
       assert(t_m >= 0.0);
       return -1;
     }


### PR DESCRIPTION
Suppress unused variable warnings when setting log level to FATAL or WARNING. 

Depends on https://github.com/nasa-jpl/jsd/pull/97 getting merged and a new semantic tag jsd:v2,.3.7 issued before merging. 