### PR TITLE
Better simulation time support

### DIFF
--- a/src/device_base.cc
+++ b/src/device_base.cc
@@ -25,7 +25,11 @@ void fastcat::DeviceBase::SetLoopPeriod(double loop_period)
   loop_period_ = loop_period;
 }
 
-void fastcat::DeviceBase::SetTime(double time) { state_->time = time; }
+void fastcat::DeviceBase::SetTime(double time, double monotonic_time)
+{
+  state_->time           = time;
+  state_->monotonic_time = monotonic_time;
+}
 
 bool fastcat::DeviceBase::Write(fastcat::DeviceCmd& /* cmd */)
 {

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -21,7 +21,7 @@ class DeviceBase
   virtual ~DeviceBase();
   // Pure virtual methods
   virtual bool ConfigFromYaml(YAML::Node node, double external_time = -1) = 0;
-  virtual bool Read()                          = 0;
+  virtual bool Read()                                                     = 0;
 
   // Non-pure virtual methods with default implementation
   virtual FaultType Process();
@@ -34,7 +34,7 @@ class DeviceBase
   std::string                  GetName();
   std::shared_ptr<DeviceState> GetState();
 
-  void SetTime(double time);
+  void SetTime(double time, double monotonic_time);
   void SetLoopPeriod(double loop_period);
 
   std::vector<Signal> signals_;

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -20,7 +20,7 @@ class DeviceBase
  public:
   virtual ~DeviceBase();
   // Pure virtual methods
-  virtual bool ConfigFromYaml(YAML::Node node) = 0;
+  virtual bool ConfigFromYaml(YAML::Node node, double external_time = -1) = 0;
   virtual bool Read()                          = 0;
 
   // Non-pure virtual methods with default implementation

--- a/src/fastcat_devices/commander.h
+++ b/src/fastcat_devices/commander.h
@@ -14,7 +14,7 @@ class Commander : public DeviceBase
 {
  public:
   Commander();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
   bool Write(DeviceCmd& cmd) override;
   void Fault() override;

--- a/src/fastcat_devices/conditional.cc
+++ b/src/fastcat_devices/conditional.cc
@@ -41,7 +41,8 @@ fastcat::Conditional::Conditional()
   state_->type = CONDITIONAL_STATE;
 }
 
-bool fastcat::Conditional::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::Conditional::ConfigFromYaml(YAML::Node node,
+                                          double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/conditional.cc
+++ b/src/fastcat_devices/conditional.cc
@@ -41,7 +41,7 @@ fastcat::Conditional::Conditional()
   state_->type = CONDITIONAL_STATE;
 }
 
-bool fastcat::Conditional::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Conditional::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/conditional.cc
+++ b/src/fastcat_devices/conditional.cc
@@ -41,7 +41,7 @@ fastcat::Conditional::Conditional()
   state_->type = CONDITIONAL_STATE;
 }
 
-bool fastcat::Conditional::ConfigFromYaml(YAML::Node node)
+bool fastcat::Conditional::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/conditional.h
+++ b/src/fastcat_devices/conditional.h
@@ -26,7 +26,7 @@ class Conditional : public DeviceBase
 {
  public:
   Conditional();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/faulter.cc
+++ b/src/fastcat_devices/faulter.cc
@@ -15,7 +15,7 @@ fastcat::Faulter::Faulter()
   state_->type = FAULTER_STATE;
 }
 
-bool fastcat::Faulter::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Faulter::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/faulter.cc
+++ b/src/fastcat_devices/faulter.cc
@@ -15,7 +15,7 @@ fastcat::Faulter::Faulter()
   state_->type = FAULTER_STATE;
 }
 
-bool fastcat::Faulter::ConfigFromYaml(YAML::Node node)
+bool fastcat::Faulter::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/faulter.h
+++ b/src/fastcat_devices/faulter.h
@@ -24,7 +24,7 @@ class Faulter : public DeviceBase
    * device.
    * @return True if configuration completes without error; false otherwise.
    */
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   /**
    * @brief Updates device state.
    * @return True if device state is read without error; false otherwise.

--- a/src/fastcat_devices/filter.cc
+++ b/src/fastcat_devices/filter.cc
@@ -101,7 +101,7 @@ fastcat::Filter::Filter()
   state_->type = FILTER_STATE;
 }
 
-bool fastcat::Filter::ConfigFromYaml(YAML::Node node)
+bool fastcat::Filter::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/filter.cc
+++ b/src/fastcat_devices/filter.cc
@@ -101,7 +101,7 @@ fastcat::Filter::Filter()
   state_->type = FILTER_STATE;
 }
 
-bool fastcat::Filter::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Filter::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/filter.h
+++ b/src/fastcat_devices/filter.h
@@ -43,7 +43,7 @@ class Filter : public DeviceBase
 {
  public:
   Filter();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/fts.cc
+++ b/src/fastcat_devices/fts.cc
@@ -15,7 +15,7 @@ fastcat::Fts::Fts()
   state_->type = FTS_STATE;
 }
 
-bool fastcat::Fts::ConfigFromYaml(YAML::Node node)
+bool fastcat::Fts::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/fts.cc
+++ b/src/fastcat_devices/fts.cc
@@ -15,7 +15,7 @@ fastcat::Fts::Fts()
   state_->type = FTS_STATE;
 }
 
-bool fastcat::Fts::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Fts::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/fts.h
+++ b/src/fastcat_devices/fts.h
@@ -24,7 +24,7 @@ class Fts : public DeviceBase
            * @param node The portion of the yaml file corresponding to this FTS device.
            * @return True if configuration completes without error; false otherwise.
            */
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   /**
    * @brief Calculates wrench (forces and torques) from input signals.
    * @return True if device state is read without error; false otherwise.

--- a/src/fastcat_devices/function.cc
+++ b/src/fastcat_devices/function.cc
@@ -35,7 +35,7 @@ fastcat::FunctionType fastcat::FunctionTypeFromString(
   }
 }
 
-bool fastcat::Function::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Function::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/function.cc
+++ b/src/fastcat_devices/function.cc
@@ -35,7 +35,7 @@ fastcat::FunctionType fastcat::FunctionTypeFromString(
   }
 }
 
-bool fastcat::Function::ConfigFromYaml(YAML::Node node)
+bool fastcat::Function::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/function.cc
+++ b/src/fastcat_devices/function.cc
@@ -35,7 +35,8 @@ fastcat::FunctionType fastcat::FunctionTypeFromString(
   }
 }
 
-bool fastcat::Function::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::Function::ConfigFromYaml(YAML::Node node,
+                                       double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/function.h
+++ b/src/fastcat_devices/function.h
@@ -37,7 +37,7 @@ class Function : public DeviceBase
 {
  public:
   Function();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/linear_interpolation.cc
+++ b/src/fastcat_devices/linear_interpolation.cc
@@ -17,7 +17,7 @@ fastcat::LinearInterpolation::LinearInterpolation()
   state_->type = LINEAR_INTERPOLATION_STATE;
 }
 
-bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/linear_interpolation.cc
+++ b/src/fastcat_devices/linear_interpolation.cc
@@ -17,7 +17,8 @@ fastcat::LinearInterpolation::LinearInterpolation()
   state_->type = LINEAR_INTERPOLATION_STATE;
 }
 
-bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node,
+                                                  double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/linear_interpolation.cc
+++ b/src/fastcat_devices/linear_interpolation.cc
@@ -17,7 +17,7 @@ fastcat::LinearInterpolation::LinearInterpolation()
   state_->type = LINEAR_INTERPOLATION_STATE;
 }
 
-bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node)
+bool fastcat::LinearInterpolation::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/linear_interpolation.h
+++ b/src/fastcat_devices/linear_interpolation.h
@@ -15,7 +15,7 @@ class LinearInterpolation : public DeviceBase
 {
  public:
   LinearInterpolation();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/pid.cc
+++ b/src/fastcat_devices/pid.cc
@@ -15,7 +15,7 @@ fastcat::Pid::Pid()
   state_->type = PID_STATE;
 }
 
-bool fastcat::Pid::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Pid::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/pid.cc
+++ b/src/fastcat_devices/pid.cc
@@ -15,7 +15,7 @@ fastcat::Pid::Pid()
   state_->type = PID_STATE;
 }
 
-bool fastcat::Pid::ConfigFromYaml(YAML::Node node)
+bool fastcat::Pid::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/pid.h
+++ b/src/fastcat_devices/pid.h
@@ -14,7 +14,7 @@ class Pid : public DeviceBase
 {
  public:
   Pid();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
   bool Write(DeviceCmd& cmd) override;
   void Fault() override;

--- a/src/fastcat_devices/saturation.cc
+++ b/src/fastcat_devices/saturation.cc
@@ -15,7 +15,7 @@ fastcat::Saturation::Saturation()
   state_->type = SATURATION_STATE;
 }
 
-bool fastcat::Saturation::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Saturation::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/saturation.cc
+++ b/src/fastcat_devices/saturation.cc
@@ -15,7 +15,7 @@ fastcat::Saturation::Saturation()
   state_->type = SATURATION_STATE;
 }
 
-bool fastcat::Saturation::ConfigFromYaml(YAML::Node node)
+bool fastcat::Saturation::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/saturation.cc
+++ b/src/fastcat_devices/saturation.cc
@@ -15,7 +15,8 @@ fastcat::Saturation::Saturation()
   state_->type = SATURATION_STATE;
 }
 
-bool fastcat::Saturation::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::Saturation::ConfigFromYaml(YAML::Node node,
+                                         double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/saturation.h
+++ b/src/fastcat_devices/saturation.h
@@ -14,7 +14,7 @@ class Saturation : public DeviceBase
 {
  public:
   Saturation();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/schmitt_trigger.cc
+++ b/src/fastcat_devices/schmitt_trigger.cc
@@ -15,7 +15,8 @@ fastcat::SchmittTrigger::SchmittTrigger()
   state_->type = SCHMITT_TRIGGER_STATE;
 }
 
-bool fastcat::SchmittTrigger::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::SchmittTrigger::ConfigFromYaml(YAML::Node node,
+                                             double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/schmitt_trigger.cc
+++ b/src/fastcat_devices/schmitt_trigger.cc
@@ -15,7 +15,7 @@ fastcat::SchmittTrigger::SchmittTrigger()
   state_->type = SCHMITT_TRIGGER_STATE;
 }
 
-bool fastcat::SchmittTrigger::ConfigFromYaml(YAML::Node node)
+bool fastcat::SchmittTrigger::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/schmitt_trigger.cc
+++ b/src/fastcat_devices/schmitt_trigger.cc
@@ -15,7 +15,7 @@ fastcat::SchmittTrigger::SchmittTrigger()
   state_->type = SCHMITT_TRIGGER_STATE;
 }
 
-bool fastcat::SchmittTrigger::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::SchmittTrigger::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/schmitt_trigger.h
+++ b/src/fastcat_devices/schmitt_trigger.h
@@ -14,7 +14,7 @@ class SchmittTrigger : public DeviceBase
 {
  public:
   SchmittTrigger();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/signal_generator.cc
+++ b/src/fastcat_devices/signal_generator.cc
@@ -33,7 +33,7 @@ fastcat::SignalGenerator::SignalGenerator()
   state_->type = SIGNAL_GENERATOR_STATE;
 }
 
-bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/signal_generator.cc
+++ b/src/fastcat_devices/signal_generator.cc
@@ -33,7 +33,8 @@ fastcat::SignalGenerator::SignalGenerator()
   state_->type = SIGNAL_GENERATOR_STATE;
 }
 
-bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node,
+                                              double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/signal_generator.cc
+++ b/src/fastcat_devices/signal_generator.cc
@@ -33,7 +33,7 @@ fastcat::SignalGenerator::SignalGenerator()
   state_->type = SIGNAL_GENERATOR_STATE;
 }
 
-bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node)
+bool fastcat::SignalGenerator::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/signal_generator.h
+++ b/src/fastcat_devices/signal_generator.h
@@ -55,7 +55,7 @@ class SignalGenerator : public DeviceBase
 {
  public:
   SignalGenerator();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -10,7 +10,7 @@ ThreeNodeThermalModel::ThreeNodeThermalModel()
   last_time_   = state_->time;  // init time
 }
 
-bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node, double external_time)
+bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -10,7 +10,8 @@ ThreeNodeThermalModel::ThreeNodeThermalModel()
   last_time_   = state_->time;  // init time
 }
 
-bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node,
+                                           double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -10,7 +10,7 @@ ThreeNodeThermalModel::ThreeNodeThermalModel()
   last_time_   = state_->time;  // init time
 }
 
-bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
+bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -29,7 +29,7 @@ class ThreeNodeThermalModel : public DeviceBase
    * @param node The portion of the yaml file corresponding to this device.
    * @return True if configuration completes without error; false otherwise.
    */
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
 
   /**
    * @brief Reads in most recent temperature and current signal values, and

--- a/src/fastcat_devices/virtual_fts.cc
+++ b/src/fastcat_devices/virtual_fts.cc
@@ -15,7 +15,8 @@ fastcat::VirtualFts::VirtualFts()
   state_->type = FTS_STATE;
 }
 
-bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node,
+                                         double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/virtual_fts.cc
+++ b/src/fastcat_devices/virtual_fts.cc
@@ -15,7 +15,7 @@ fastcat::VirtualFts::VirtualFts()
   state_->type = FTS_STATE;
 }
 
-bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node)
+bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/virtual_fts.cc
+++ b/src/fastcat_devices/virtual_fts.cc
@@ -15,7 +15,7 @@ fastcat::VirtualFts::VirtualFts()
   state_->type = FTS_STATE;
 }
 
-bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::VirtualFts::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fastcat_devices/virtual_fts.h
+++ b/src/fastcat_devices/virtual_fts.h
@@ -27,7 +27,7 @@ class VirtualFts : public Fts
    * device.
    * @return True if configuration completes without error; false otherwise.
    */
-  bool ConfigFromYaml(YAML::Node node);
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1);
   /**
    * @brief Calculates wrench (forces and torques) from input signals.
    * @return True if device state is read without error; false otherwise.

--- a/src/fcgen/commander.cc.cog
+++ b/src/fcgen/commander.cc.cog
@@ -37,7 +37,7 @@ fastcat::Commander::Commander()
   
 }
 
-bool fastcat::Commander::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Commander::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fcgen/commander.cc.cog
+++ b/src/fcgen/commander.cc.cog
@@ -37,7 +37,7 @@ fastcat::Commander::Commander()
   
 }
 
-bool fastcat::Commander::ConfigFromYaml(YAML::Node node)
+bool fastcat::Commander::ConfigFromYaml(YAML::Node node, double external_time)
 {
   if (!ParseVal(node, "name", name_)) {
     return false;

--- a/src/fcgen/types.h.cog
+++ b/src/fcgen/types.h.cog
@@ -115,6 +115,7 @@ for state in data['states']:
 
   };
   double time;
+  double monotonic_time;
 } DeviceState;
 
 

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -30,7 +30,7 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node, double external_time)
   if(external_time > 0) {
     last_transition_time_ = external_time;
   } else {
-    last_transition_time_ = jsd_time_get_mono_time_sec();
+    last_transition_time_ = jsd_time_get_time_sec();
   }
 
   if (!ParseVal(node, "name", name_)) {
@@ -229,12 +229,8 @@ bool fastcat::Actuator::ConfigFromYaml(YAML::Node node, double external_time)
 
 bool fastcat::Actuator::Read()
 {
-  cycle_mono_time_ = jsd_time_get_mono_time_sec();
-
   ElmoRead();
-
   PopulateState();
-
   return true;
 }
 
@@ -598,7 +594,7 @@ bool fastcat::Actuator::CurrentExceedsCmdLimits(double current)
 
 void fastcat::Actuator::TransitionToState(ActuatorStateMachineState sms)
 {
-  last_transition_time_ = cycle_mono_time_;
+  last_transition_time_ = state_->time;
   if (actuator_sms_ != sms) {
     MSG("Requested Actuator %s state transition from %s to %s", name_.c_str(),
         StateMachineStateToString(actuator_sms_).c_str(),

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -19,14 +19,20 @@
 fastcat::Actuator::Actuator()
 {
   MSG_DEBUG("Constructed Actuator");
-
   state_                = std::make_shared<DeviceState>();
-  actuator_sms_         = ACTUATOR_SMS_HALTED;
-  last_transition_time_ = jsd_time_get_mono_time_sec();
 }
 
-bool fastcat::Actuator::ConfigFromYaml(YAML::Node node)
+
+bool fastcat::Actuator::ConfigFromYaml(YAML::Node node, double external_time)
 {
+  actuator_sms_         = ACTUATOR_SMS_HALTED;
+  
+  if(external_time > 0) {
+    last_transition_time_ = external_time;
+  } else {
+    last_transition_time_ = jsd_time_get_mono_time_sec();
+  }
+
   if (!ParseVal(node, "name", name_)) {
     return false;
   }

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -54,7 +54,7 @@ class Actuator : public JsdDeviceBase
  public:
   Actuator();
 
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -128,9 +128,8 @@ class Actuator : public JsdDeviceBase
 
   jsd_slave_config_t jsd_slave_config_ = {};
 
-  ActuatorStateMachineState actuator_sms_;
+  ActuatorStateMachineState actuator_sms_         = ACTUATOR_SMS_HALTED;
   double                    last_transition_time_ = 0.0;
-  double                    cycle_mono_time_      = 0.0;
   fastcat_trap_t            trap_                 = {};
   ActuatorParams            params_               = {};
 

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -499,7 +499,7 @@ fastcat::FaultType fastcat::Actuator::ProcessHolding()
     return ALL_DEVICE_FAULT;
   }
 
-  if ((cycle_mono_time_ - last_transition_time_) >
+  if ((state_->time - last_transition_time_) >
       params_.holding_duration_sec) {
     ElmoHalt();
     TransitionToState(ACTUATOR_SMS_HALTED);
@@ -540,7 +540,7 @@ fastcat::FaultType fastcat::Actuator::ProcessCS()
     return ALL_DEVICE_FAULT;
   }
 
-  if ((cycle_mono_time_ - last_transition_time_) > 5 * loop_period_) {
+  if ((state_->time - last_transition_time_) > 5 * loop_period_) {
     TransitionToState(ACTUATOR_SMS_HOLDING);
   }
 
@@ -613,10 +613,10 @@ fastcat::FaultType fastcat::Actuator::ProcessCalAtHardstop()
           JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED &&
       IsJsdFaultCodePresent(*state_)) {
     // We have waited too long, fault
-    if ((cycle_mono_time_ - last_transition_time_) > 5.0) {
+    if ((state_->time - last_transition_time_) > 5.0) {
       ERROR("Act %s: %s: %lf", name_.c_str(),
             "Waited too long for drive to reset in CAL_AT_HARDSTOP state",
-            (cycle_mono_time_ - last_transition_time_));
+            (state_->time - last_transition_time_));
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CAL_RESET_TIMEOUT_EXCEEDED;
       return ALL_DEVICE_FAULT;
     }

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -499,7 +499,7 @@ fastcat::FaultType fastcat::Actuator::ProcessHolding()
     return ALL_DEVICE_FAULT;
   }
 
-  if ((state_->time - last_transition_time_) >
+  if ((state_->monotonic_time - last_transition_time_) >
       params_.holding_duration_sec) {
     ElmoHalt();
     TransitionToState(ACTUATOR_SMS_HALTED);
@@ -540,7 +540,7 @@ fastcat::FaultType fastcat::Actuator::ProcessCS()
     return ALL_DEVICE_FAULT;
   }
 
-  if ((state_->time - last_transition_time_) > 5 * loop_period_) {
+  if ((state_->monotonic_time - last_transition_time_) > 5 * loop_period_) {
     TransitionToState(ACTUATOR_SMS_HOLDING);
   }
 
@@ -613,10 +613,10 @@ fastcat::FaultType fastcat::Actuator::ProcessCalAtHardstop()
           JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED &&
       IsJsdFaultCodePresent(*state_)) {
     // We have waited too long, fault
-    if ((state_->time - last_transition_time_) > 5.0) {
+    if ((state_->monotonic_time - last_transition_time_) > 5.0) {
       ERROR("Act %s: %s: %lf", name_.c_str(),
             "Waited too long for drive to reset in CAL_AT_HARDSTOP state",
-            (state_->time - last_transition_time_));
+            (state_->monotonic_time - last_transition_time_));
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_CAL_RESET_TIMEOUT_EXCEEDED;
       return ALL_DEVICE_FAULT;
     }

--- a/src/jsd/ati_fts.cc
+++ b/src/jsd/ati_fts.cc
@@ -67,7 +67,7 @@ bool fastcat::AtiFts::ConfigFromYamlCommon(YAML::Node node)
   return true;
 }
 
-bool fastcat::AtiFts::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::AtiFts::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/ati_fts.cc
+++ b/src/jsd/ati_fts.cc
@@ -67,7 +67,7 @@ bool fastcat::AtiFts::ConfigFromYamlCommon(YAML::Node node)
   return true;
 }
 
-bool fastcat::AtiFts::ConfigFromYaml(YAML::Node node)
+bool fastcat::AtiFts::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/ati_fts.h
+++ b/src/jsd/ati_fts.h
@@ -15,7 +15,7 @@ class AtiFts : public JsdDeviceBase
 {
  public:
   AtiFts();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/ati_fts_offline.cc
+++ b/src/jsd/ati_fts_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/ati_fts_offline.cc
+++ b/src/jsd/ati_fts_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node)
+bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/ati_fts_offline.cc
+++ b/src/jsd/ati_fts_offline.cc
@@ -5,7 +5,8 @@
 
 // Include external then project includes
 
-bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::AtiFtsOffline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/ati_fts_offline.h
+++ b/src/jsd/ati_fts_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class AtiFtsOffline : public AtiFts
 {
  public:
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
 };

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -18,7 +18,7 @@ fastcat::Egd::Egd()
   state_->type = EGD_STATE;
 }
 
-bool fastcat::Egd::ConfigFromYaml(YAML::Node node)
+bool fastcat::Egd::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config(context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -18,7 +18,7 @@ fastcat::Egd::Egd()
   state_->type = EGD_STATE;
 }
 
-bool fastcat::Egd::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Egd::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config(context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/egd.h
+++ b/src/jsd/egd.h
@@ -15,7 +15,7 @@ class Egd : public JsdDeviceBase
 {
  public:
   Egd();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/egd_offline.cc
+++ b/src/jsd/egd_offline.cc
@@ -11,7 +11,7 @@
 
 fastcat::EgdOffline::EgdOffline() { MSG_DEBUG("Constructed EgdOffline"); }
 
-bool fastcat::EgdOffline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::EgdOffline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/egd_offline.cc
+++ b/src/jsd/egd_offline.cc
@@ -11,7 +11,8 @@
 
 fastcat::EgdOffline::EgdOffline() { MSG_DEBUG("Constructed EgdOffline"); }
 
-bool fastcat::EgdOffline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::EgdOffline::ConfigFromYaml(YAML::Node node,
+                                         double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/egd_offline.cc
+++ b/src/jsd/egd_offline.cc
@@ -11,7 +11,7 @@
 
 fastcat::EgdOffline::EgdOffline() { MSG_DEBUG("Constructed EgdOffline"); }
 
-bool fastcat::EgdOffline::ConfigFromYaml(YAML::Node node)
+bool fastcat::EgdOffline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/egd_offline.h
+++ b/src/jsd/egd_offline.h
@@ -14,7 +14,7 @@ class EgdOffline : public Egd
 {
  public:
   EgdOffline();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/el2124.cc
+++ b/src/jsd/el2124.cc
@@ -18,7 +18,7 @@ fastcat::El2124::El2124()
   state_->type = EL2124_STATE;
 }
 
-bool fastcat::El2124::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El2124::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el2124.cc
+++ b/src/jsd/el2124.cc
@@ -18,7 +18,7 @@ fastcat::El2124::El2124()
   state_->type = EL2124_STATE;
 }
 
-bool fastcat::El2124::ConfigFromYaml(YAML::Node node)
+bool fastcat::El2124::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el2124.h
+++ b/src/jsd/el2124.h
@@ -15,7 +15,7 @@ class El2124 : public JsdDeviceBase
 {
  public:
   El2124();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/el2124_offline.cc
+++ b/src/jsd/el2124_offline.cc
@@ -10,7 +10,7 @@
 // Include external then project includes
 #include "fastcat/yaml_parser.h"
 
-bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el2124_offline.cc
+++ b/src/jsd/el2124_offline.cc
@@ -10,7 +10,8 @@
 // Include external then project includes
 #include "fastcat/yaml_parser.h"
 
-bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el2124_offline.cc
+++ b/src/jsd/el2124_offline.cc
@@ -10,7 +10,7 @@
 // Include external then project includes
 #include "fastcat/yaml_parser.h"
 
-bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El2124Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el2124_offline.h
+++ b/src/jsd/el2124_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El2124Offline : public El2124
 {
  public:
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/el3104.cc
+++ b/src/jsd/el3104.cc
@@ -18,7 +18,7 @@ fastcat::El3104::El3104()
   state_->type = EL3104_STATE;
 }
 
-bool fastcat::El3104::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3104::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3104.cc
+++ b/src/jsd/el3104.cc
@@ -18,7 +18,7 @@ fastcat::El3104::El3104()
   state_->type = EL3104_STATE;
 }
 
-bool fastcat::El3104::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3104::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3104.h
+++ b/src/jsd/el3104.h
@@ -15,7 +15,7 @@ class El3104 : public JsdDeviceBase
 {
  public:
   El3104();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/jsd/el3104_offline.cc
+++ b/src/jsd/el3104_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3104_offline.cc
+++ b/src/jsd/el3104_offline.cc
@@ -9,7 +9,8 @@
 
 // Include external then project includes
 
-bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3104_offline.cc
+++ b/src/jsd/el3104_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3104Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3104_offline.h
+++ b/src/jsd/el3104_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El3104Offline : public El3104
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/el3162.cc
+++ b/src/jsd/el3162.cc
@@ -14,7 +14,7 @@ fastcat::El3162::El3162()
   state_->type = EL3162_STATE;
 }
 
-bool fastcat::El3162::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3162::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3162.cc
+++ b/src/jsd/el3162.cc
@@ -14,7 +14,7 @@ fastcat::El3162::El3162()
   state_->type = EL3162_STATE;
 }
 
-bool fastcat::El3162::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3162::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3162.h
+++ b/src/jsd/el3162.h
@@ -15,7 +15,7 @@ class El3162 : public JsdDeviceBase
 {
  public:
   El3162();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/jsd/el3162_offline.cc
+++ b/src/jsd/el3162_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3162Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3162Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3162_offline.cc
+++ b/src/jsd/el3162_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3162Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3162Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3162_offline.cc
+++ b/src/jsd/el3162_offline.cc
@@ -5,7 +5,8 @@
 
 // Include external then project includes
 
-bool fastcat::El3162Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El3162Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3162_offline.h
+++ b/src/jsd/el3162_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El3162Offline : public El3162
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/el3202.cc
+++ b/src/jsd/el3202.cc
@@ -18,7 +18,7 @@ fastcat::El3202::El3202()
   state_->type = EL3202_STATE;
 }
 
-bool fastcat::El3202::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3202::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3202.cc
+++ b/src/jsd/el3202.cc
@@ -18,7 +18,7 @@ fastcat::El3202::El3202()
   state_->type = EL3202_STATE;
 }
 
-bool fastcat::El3202::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3202::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3202.h
+++ b/src/jsd/el3202.h
@@ -15,7 +15,7 @@ class El3202 : public JsdDeviceBase
 {
  public:
   El3202();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/jsd/el3202_offline.cc
+++ b/src/jsd/el3202_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3202_offline.cc
+++ b/src/jsd/el3202_offline.cc
@@ -9,7 +9,8 @@
 
 // Include external then project includes
 
-bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3202_offline.cc
+++ b/src/jsd/el3202_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3202Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3202_offline.h
+++ b/src/jsd/el3202_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El3202Offline : public El3202
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/el3208.cc
+++ b/src/jsd/el3208.cc
@@ -28,7 +28,7 @@ fastcat::El3208::El3208()
   outputs_[7] = &state_->el3208_state.output_ch8;
 }
 
-bool fastcat::El3208::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3208::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3208.cc
+++ b/src/jsd/el3208.cc
@@ -28,7 +28,7 @@ fastcat::El3208::El3208()
   outputs_[7] = &state_->el3208_state.output_ch8;
 }
 
-bool fastcat::El3208::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3208::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3208.h
+++ b/src/jsd/el3208.h
@@ -15,7 +15,7 @@ class El3208 : public JsdDeviceBase
 {
  public:
   El3208();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
 

--- a/src/jsd/el3208_offline.cc
+++ b/src/jsd/el3208_offline.cc
@@ -10,7 +10,7 @@
 // Include external then project includes
 #include "fastcat/yaml_parser.h"
 
-bool fastcat::El3208Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3208Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3208_offline.cc
+++ b/src/jsd/el3208_offline.cc
@@ -10,7 +10,7 @@
 // Include external then project includes
 #include "fastcat/yaml_parser.h"
 
-bool fastcat::El3208Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3208Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3208_offline.cc
+++ b/src/jsd/el3208_offline.cc
@@ -10,7 +10,8 @@
 // Include external then project includes
 #include "fastcat/yaml_parser.h"
 
-bool fastcat::El3208Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El3208Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3208_offline.h
+++ b/src/jsd/el3208_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El3208Offline : public El3208
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/el3318.cc
+++ b/src/jsd/el3318.cc
@@ -18,7 +18,7 @@ fastcat::El3318::El3318()
   state_->type = EL3318_STATE;
 }
 
-bool fastcat::El3318::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3318::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3318.cc
+++ b/src/jsd/el3318.cc
@@ -18,7 +18,7 @@ fastcat::El3318::El3318()
   state_->type = EL3318_STATE;
 }
 
-bool fastcat::El3318::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3318::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3318.h
+++ b/src/jsd/el3318.h
@@ -15,7 +15,7 @@ class El3318 : public JsdDeviceBase
 {
  public:
   El3318();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/jsd/el3318_offline.cc
+++ b/src/jsd/el3318_offline.cc
@@ -9,7 +9,8 @@
 
 // Include external then project includes
 
-bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3318_offline.cc
+++ b/src/jsd/el3318_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3318_offline.cc
+++ b/src/jsd/el3318_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3318Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3318_offline.h
+++ b/src/jsd/el3318_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El3318Offline : public El3318
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/el3602.cc
+++ b/src/jsd/el3602.cc
@@ -18,7 +18,7 @@ fastcat::El3602::El3602()
   state_->type = EL3602_STATE;
 }
 
-bool fastcat::El3602::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3602::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3602.cc
+++ b/src/jsd/el3602.cc
@@ -18,7 +18,7 @@ fastcat::El3602::El3602()
   state_->type = EL3602_STATE;
 }
 
-bool fastcat::El3602::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3602::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el3602.h
+++ b/src/jsd/el3602.h
@@ -15,7 +15,7 @@ class El3602 : public JsdDeviceBase
 {
  public:
   El3602();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/jsd/el3602_offline.cc
+++ b/src/jsd/el3602_offline.cc
@@ -9,7 +9,8 @@
 
 // Include external then project includes
 
-bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3602_offline.cc
+++ b/src/jsd/el3602_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3602_offline.cc
+++ b/src/jsd/el3602_offline.cc
@@ -9,7 +9,7 @@
 
 // Include external then project includes
 
-bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El3602Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el3602_offline.h
+++ b/src/jsd/el3602_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El3602Offline : public El3602
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/el4102.cc
+++ b/src/jsd/el4102.cc
@@ -18,7 +18,7 @@ fastcat::El4102::El4102()
   state_->type = EL4102_STATE;
 }
 
-bool fastcat::El4102::ConfigFromYaml(YAML::Node node)
+bool fastcat::El4102::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el4102.cc
+++ b/src/jsd/el4102.cc
@@ -18,7 +18,7 @@ fastcat::El4102::El4102()
   state_->type = EL4102_STATE;
 }
 
-bool fastcat::El4102::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El4102::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/el4102.h
+++ b/src/jsd/el4102.h
@@ -15,7 +15,7 @@ class El4102 : public JsdDeviceBase
 {
  public:
   El4102();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/el4102_offline.cc
+++ b/src/jsd/el4102_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el4102_offline.cc
+++ b/src/jsd/el4102_offline.cc
@@ -5,7 +5,8 @@
 
 // Include external then project includes
 
-bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node,
+                                            double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el4102_offline.cc
+++ b/src/jsd/el4102_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::El4102Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/el4102_offline.h
+++ b/src/jsd/el4102_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class El4102Offline : public El4102
 {
  public:
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/gold_actuator.cc
+++ b/src/jsd/gold_actuator.cc
@@ -346,7 +346,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfPosDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((cycle_mono_time_ - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -389,7 +389,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfVelDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((cycle_mono_time_ - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -430,7 +430,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfTorqueDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((cycle_mono_time_ - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;

--- a/src/jsd/gold_actuator.cc
+++ b/src/jsd/gold_actuator.cc
@@ -346,7 +346,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfPosDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -389,7 +389,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfVelDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -430,7 +430,7 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfTorqueDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;

--- a/src/jsd/gold_actuator.cc
+++ b/src/jsd/gold_actuator.cc
@@ -346,7 +346,8 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfPosDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) >
+        (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -389,7 +390,8 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfVelDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) >
+        (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -430,7 +432,8 @@ fastcat::FaultType fastcat::GoldActuator::ProcessProfTorqueDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) >
+        (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;

--- a/src/jsd/gold_actuator_offline.cc
+++ b/src/jsd/gold_actuator_offline.cc
@@ -14,7 +14,15 @@ fastcat::GoldActuatorOffline::GoldActuatorOffline()
 {
   MSG_DEBUG("Constructed GoldActuatorOffline");
   memset(&jsd_egd_state_, 0, sizeof(jsd_egd_state_t));
-  motor_on_start_time_ = jsd_time_get_time_sec();
+}
+
+bool fastcat::GoldActuatorOffline::ConfigFromYaml(YAML::Node node, double external_time) {
+  if(external_time < 0) {
+    motor_on_start_time_ = jsd_time_get_time_sec();
+  } else {
+    motor_on_start_time_ = external_time;
+  }
+  return fastcat::GoldActuator::ConfigFromYaml(node, external_time);
 }
 
 void fastcat::GoldActuatorOffline::ElmoSetConfig()
@@ -51,13 +59,13 @@ void fastcat::GoldActuatorOffline::ElmoProcess()
 
   // reset motor_on timer on rising edge
   if (!last_motor_on_state_ && jsd_egd_state_.motor_on) {
-    motor_on_start_time_ = jsd_time_get_time_sec();
+    motor_on_start_time_ = state_->time;
   }
   last_motor_on_state_ = jsd_egd_state_.motor_on;
 
   //
   if (!jsd_egd_state_.servo_enabled && jsd_egd_state_.motor_on) {
-    double brake_on_dur = jsd_time_get_time_sec() - motor_on_start_time_;
+    double brake_on_dur = state_->time - motor_on_start_time_;
     if (brake_on_dur > params_.elmo_brake_disengage_msec / 1000.0) {
       jsd_egd_state_.servo_enabled = 1;
     }
@@ -68,9 +76,9 @@ void fastcat::GoldActuatorOffline::ElmoFault()
 {
   MSG("Faulting EGD through JSD: %s", name_.c_str());
 
-  // TODO review with david
+  // TODO review with David Kim
   // need to clear so that old commands are not left over
-  //  for new commands
+  // for new commands
   jsd_egd_state_.cmd_position = 0;
   jsd_egd_state_.cmd_velocity = 0;
   jsd_egd_state_.cmd_current  = 0;
@@ -126,18 +134,17 @@ void fastcat::GoldActuatorOffline::ElmoCSP(
   jsd_egd_state_.cmd_ff_velocity = jsd_csp_cmd.velocity_offset;
   jsd_egd_state_.cmd_ff_current  = jsd_csp_cmd.torque_offset_amps;
 
-  // Differentiate position to get actual_velocity
+  // Perform numerical differencing of position to get actual_velocity
   double vel = (jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position -
                 jsd_egd_state_.actual_position) /
                loop_period_;
 
-  // simulate actuals
+  // simulate actual position, current and velocity
   jsd_egd_state_.actual_position =
       jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position;
   jsd_egd_state_.actual_current =
       jsd_egd_state_.cmd_current + jsd_egd_state_.cmd_ff_current;
-
-  jsd_egd_state_.actual_velocity = vel;  // "sure, why not"
+  jsd_egd_state_.actual_velocity = vel;
 }
 
 void fastcat::GoldActuatorOffline::ElmoCSV(

--- a/src/jsd/gold_actuator_offline.cc
+++ b/src/jsd/gold_actuator_offline.cc
@@ -16,8 +16,10 @@ fastcat::GoldActuatorOffline::GoldActuatorOffline()
   memset(&jsd_egd_state_, 0, sizeof(jsd_egd_state_t));
 }
 
-bool fastcat::GoldActuatorOffline::ConfigFromYaml(YAML::Node node, double external_time) {
-  if(external_time < 0) {
+bool fastcat::GoldActuatorOffline::ConfigFromYaml(YAML::Node node,
+                                                  double     external_time)
+{
+  if (external_time < 0) {
     motor_on_start_time_ = jsd_time_get_time_sec();
   } else {
     motor_on_start_time_ = external_time;

--- a/src/jsd/gold_actuator_offline.cc
+++ b/src/jsd/gold_actuator_offline.cc
@@ -13,7 +13,6 @@
 fastcat::GoldActuatorOffline::GoldActuatorOffline()
 {
   MSG_DEBUG("Constructed GoldActuatorOffline");
-
   memset(&jsd_egd_state_, 0, sizeof(jsd_egd_state_t));
   motor_on_start_time_ = jsd_time_get_time_sec();
 }

--- a/src/jsd/gold_actuator_offline.h
+++ b/src/jsd/gold_actuator_offline.h
@@ -14,6 +14,7 @@ class GoldActuatorOffline : public GoldActuator
 {
  public:
   GoldActuatorOffline();
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
 
  private:
   void ElmoSetConfig() override;

--- a/src/jsd/ild1900.cc
+++ b/src/jsd/ild1900.cc
@@ -14,7 +14,7 @@ fastcat::Ild1900::Ild1900()
   state_->type = ILD1900_STATE;
 }
 
-bool fastcat::Ild1900::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Ild1900::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/ild1900.cc
+++ b/src/jsd/ild1900.cc
@@ -14,7 +14,7 @@ fastcat::Ild1900::Ild1900()
   state_->type = ILD1900_STATE;
 }
 
-bool fastcat::Ild1900::ConfigFromYaml(YAML::Node node)
+bool fastcat::Ild1900::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/ild1900.h
+++ b/src/jsd/ild1900.h
@@ -15,7 +15,7 @@ class Ild1900 : public JsdDeviceBase
 {
  public:
   Ild1900();
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 
  protected:

--- a/src/jsd/ild1900_offline.cc
+++ b/src/jsd/ild1900_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::Ild1900Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Ild1900Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/ild1900_offline.cc
+++ b/src/jsd/ild1900_offline.cc
@@ -5,7 +5,7 @@
 
 // Include external then project includes
 
-bool fastcat::Ild1900Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::Ild1900Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/ild1900_offline.cc
+++ b/src/jsd/ild1900_offline.cc
@@ -5,7 +5,8 @@
 
 // Include external then project includes
 
-bool fastcat::Ild1900Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::Ild1900Offline::ConfigFromYaml(YAML::Node node,
+                                             double /*external_time*/)
 {
   return ConfigFromYamlCommon(node);
 }

--- a/src/jsd/ild1900_offline.h
+++ b/src/jsd/ild1900_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class Ild1900Offline : public Ild1900
 {
  public:
-  bool ConfigFromYaml(YAML::Node node) override;
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool Read() override;
 };
 

--- a/src/jsd/jed0101.cc
+++ b/src/jsd/jed0101.cc
@@ -16,7 +16,7 @@ fastcat::Jed0101::Jed0101()
   state_->type = JED0101_STATE;
 }
 
-bool fastcat::Jed0101::ConfigFromYaml(YAML::Node node)
+bool fastcat::Jed0101::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/jed0101.cc
+++ b/src/jsd/jed0101.cc
@@ -16,7 +16,7 @@ fastcat::Jed0101::Jed0101()
   state_->type = JED0101_STATE;
 }
 
-bool fastcat::Jed0101::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Jed0101::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/jed0101.h
+++ b/src/jsd/jed0101.h
@@ -15,7 +15,7 @@ class Jed0101 : public JsdDeviceBase
 {
  public:
   Jed0101();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/jed0101_offline.cc
+++ b/src/jsd/jed0101_offline.cc
@@ -7,7 +7,7 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval               = ConfigFromYamlCommon(node);
   state_->jed0101_state.cmd = initial_cmd_;

--- a/src/jsd/jed0101_offline.cc
+++ b/src/jsd/jed0101_offline.cc
@@ -7,7 +7,8 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node,
+                                             double /*external_time*/)
 {
   bool retval               = ConfigFromYamlCommon(node);
   state_->jed0101_state.cmd = initial_cmd_;

--- a/src/jsd/jed0101_offline.cc
+++ b/src/jsd/jed0101_offline.cc
@@ -7,7 +7,7 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::Jed0101Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval               = ConfigFromYamlCommon(node);
   state_->jed0101_state.cmd = initial_cmd_;

--- a/src/jsd/jed0101_offline.h
+++ b/src/jsd/jed0101_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class Jed0101Offline : public Jed0101
 {
  public:
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/jed0200.cc
+++ b/src/jsd/jed0200.cc
@@ -16,7 +16,7 @@ fastcat::Jed0200::Jed0200()
   state_->type = JED0200_STATE;
 }
 
-bool fastcat::Jed0200::ConfigFromYaml(YAML::Node node)
+bool fastcat::Jed0200::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/jed0200.cc
+++ b/src/jsd/jed0200.cc
@@ -16,7 +16,7 @@ fastcat::Jed0200::Jed0200()
   state_->type = JED0200_STATE;
 }
 
-bool fastcat::Jed0200::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Jed0200::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval = ConfigFromYamlCommon(node);
   jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);

--- a/src/jsd/jed0200.h
+++ b/src/jsd/jed0200.h
@@ -15,7 +15,7 @@ class Jed0200 : public JsdDeviceBase
 {
  public:
   Jed0200();
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/jed0200_offline.cc
+++ b/src/jsd/jed0200_offline.cc
@@ -7,7 +7,7 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node, double external_time)
+bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
 {
   bool retval               = ConfigFromYamlCommon(node);
   state_->jed0200_state.cmd = initial_cmd_;

--- a/src/jsd/jed0200_offline.cc
+++ b/src/jsd/jed0200_offline.cc
@@ -7,7 +7,7 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node)
+bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node, double external_time)
 {
   bool retval               = ConfigFromYamlCommon(node);
   state_->jed0200_state.cmd = initial_cmd_;

--- a/src/jsd/jed0200_offline.cc
+++ b/src/jsd/jed0200_offline.cc
@@ -7,7 +7,8 @@
 // Include external then project includes
 #include "jsd/jsd_print.h"
 
-bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node, double /*external_time*/)
+bool fastcat::Jed0200Offline::ConfigFromYaml(YAML::Node node,
+                                             double /*external_time*/)
 {
   bool retval               = ConfigFromYamlCommon(node);
   state_->jed0200_state.cmd = initial_cmd_;

--- a/src/jsd/jed0200_offline.h
+++ b/src/jsd/jed0200_offline.h
@@ -13,7 +13,7 @@ namespace fastcat
 class Jed0200Offline : public Jed0200
 {
  public:
-  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      ConfigFromYaml(YAML::Node node, double external_time = -1) override;
   bool      Read() override;
   FaultType Process() override;
   bool      Write(DeviceCmd& cmd) override;

--- a/src/jsd/platinum_actuator.cc
+++ b/src/jsd/platinum_actuator.cc
@@ -198,7 +198,7 @@ fastcat::FaultType fastcat::PlatinumActuator::ProcessProfPosDisengaging()
   // fault.
   if (state_->platinum_actuator_state.setpoint_ack_rise) {
     TransitionToState(ACTUATOR_SMS_PROF_POS);
-  } else if ((cycle_mono_time_ - last_transition_time_) >
+  } else if ((state_->time - last_transition_time_) >
              (1.0 + 2.0 * loop_period_)) {
     ERROR(
         "Act %s: Profiled Position command was not acknowledged by drive "
@@ -239,7 +239,7 @@ fastcat::FaultType fastcat::PlatinumActuator::ProcessProfVel()
   // If max_duration is greater than zero, zero out the target after the
   // commanded duration.
   if (last_cmd_.actuator_prof_vel_cmd.max_duration > 1e-9 &&
-      (cycle_mono_time_ - last_transition_time_) >
+      (state_->time - last_transition_time_) >
           last_cmd_.actuator_prof_vel_cmd.max_duration) {
     TransitionToState(ACTUATOR_SMS_HOLDING);
 
@@ -273,7 +273,7 @@ fastcat::FaultType fastcat::PlatinumActuator::ProcessProfTorque()
   // If max_duration is greater than zero, zero out the target after the
   // commanded duration.
   if (last_cmd_.actuator_prof_torque_cmd.max_duration > 1e-9 &&
-      (cycle_mono_time_ - last_transition_time_) >
+      (state_->time - last_transition_time_) >
           last_cmd_.actuator_prof_torque_cmd.max_duration) {
     TransitionToState(ACTUATOR_SMS_HOLDING);
 

--- a/src/jsd/platinum_actuator.cc
+++ b/src/jsd/platinum_actuator.cc
@@ -198,7 +198,7 @@ fastcat::FaultType fastcat::PlatinumActuator::ProcessProfPosDisengaging()
   // fault.
   if (state_->platinum_actuator_state.setpoint_ack_rise) {
     TransitionToState(ACTUATOR_SMS_PROF_POS);
-  } else if ((state_->time - last_transition_time_) >
+  } else if ((state_->monotonic_time - last_transition_time_) >
              (1.0 + 2.0 * loop_period_)) {
     ERROR(
         "Act %s: Profiled Position command was not acknowledged by drive "
@@ -239,7 +239,7 @@ fastcat::FaultType fastcat::PlatinumActuator::ProcessProfVel()
   // If max_duration is greater than zero, zero out the target after the
   // commanded duration.
   if (last_cmd_.actuator_prof_vel_cmd.max_duration > 1e-9 &&
-      (state_->time - last_transition_time_) >
+      (state_->monotonic_time - last_transition_time_) >
           last_cmd_.actuator_prof_vel_cmd.max_duration) {
     TransitionToState(ACTUATOR_SMS_HOLDING);
 
@@ -273,7 +273,7 @@ fastcat::FaultType fastcat::PlatinumActuator::ProcessProfTorque()
   // If max_duration is greater than zero, zero out the target after the
   // commanded duration.
   if (last_cmd_.actuator_prof_torque_cmd.max_duration > 1e-9 &&
-      (state_->time - last_transition_time_) >
+      (state_->monotonic_time - last_transition_time_) >
           last_cmd_.actuator_prof_torque_cmd.max_duration) {
     TransitionToState(ACTUATOR_SMS_HOLDING);
 

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -186,7 +186,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfPosDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -229,7 +229,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfVelDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -271,7 +271,7 @@ fastcat::PlatinumActuatorOffline::ProcessProfTorqueDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->monotonic_time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -177,7 +177,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfPosDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((cycle_mono_time_ - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -220,7 +220,7 @@ fastcat::FaultType fastcat::PlatinumActuatorOffline::ProcessProfVelDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((cycle_mono_time_ - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;
@@ -262,7 +262,7 @@ fastcat::PlatinumActuatorOffline::ProcessProfTorqueDisengaging()
 
     // Check runout timer here, brake engage/disengage time cannot exceed 1
     // second per MAN-G-CR Section BP - Brake Parameters
-    if ((cycle_mono_time_ - last_transition_time_) > (1.0 + 2 * loop_period_)) {
+    if ((state_->time - last_transition_time_) > (1.0 + 2 * loop_period_)) {
       ERROR("Act %s: Brake Disengage 1.0 sec runout timer expired, faulting",
             name_.c_str());
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_BRAKE_DISENGAGE_TIMEOUT_EXCEEDED;

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -16,8 +16,10 @@ fastcat::PlatinumActuatorOffline::PlatinumActuatorOffline()
   memset(&jsd_epd_state_, 0, sizeof(jsd_epd_state_t));
 }
 
-bool fastcat::PlatinumActuatorOffline::ConfigFromYaml(YAML::Node node, double external_time) {
-  if(external_time < 0) {
+bool fastcat::PlatinumActuatorOffline::ConfigFromYaml(YAML::Node node,
+                                                      double     external_time)
+{
+  if (external_time < 0) {
     motor_on_start_time_ = jsd_time_get_time_sec();
   } else {
     motor_on_start_time_ = external_time;

--- a/src/jsd/platinum_actuator_offline.h
+++ b/src/jsd/platinum_actuator_offline.h
@@ -14,6 +14,7 @@ class PlatinumActuatorOffline : public PlatinumActuator
 {
  public:
   PlatinumActuatorOffline();
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1) override;
 
  private:
   bool HandleNewProfPosCmdImpl(const DeviceCmd& cmd) override;

--- a/src/manager.h
+++ b/src/manager.h
@@ -178,9 +178,9 @@ class Manager
                             fastcat::DeviceStateType);
 
  private:
-  bool ConfigJSDBusFromYaml(YAML::Node node);
-  bool ConfigFastcatBusFromYaml(YAML::Node node);
-  bool ConfigOfflineBusFromYaml(YAML::Node node);
+  bool ConfigJSDBusFromYaml(YAML::Node node, double external_time);
+  bool ConfigFastcatBusFromYaml(YAML::Node node, double external_time);
+  bool ConfigOfflineBusFromYaml(YAML::Node node, double external_time);
   bool WriteCommands();
   bool ConfigSignals();
   bool SortFastcatDevice(

--- a/src/manager.h
+++ b/src/manager.h
@@ -43,7 +43,7 @@ class Manager
    *  @return true on successful initialization. If false, application should
    * quit.
    */
-  bool ConfigFromYaml(YAML::Node node);
+  bool ConfigFromYaml(YAML::Node node, double external_time = -1);
 
   /** @brief Updates synchronous PDO and background async SDO requests.
    *

--- a/test/test_unit/test_three_node_thermal_model.cc
+++ b/test/test_unit/test_three_node_thermal_model.cc
@@ -116,25 +116,25 @@ TEST_F(ThreeNodeThermalModelTest, CurrentInput)
   *node_3_temp_input   = 20.0;
   *motor_current_input = 1.0;
   EXPECT_TRUE(device_.Read());
-  device_.SetTime(1.0);
+  device_.SetTime(1.0, 1.0);
   EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
   EXPECT_NEAR(*node_1_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_2_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_4_temp_output, 20.333333333333, DOUBLE_COMP_THRESHOLD);
-  device_.SetTime(2.0);
+  device_.SetTime(2.0, 2.0);
   EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
   EXPECT_NEAR(*node_1_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_2_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_4_temp_output, 20.666666666666, DOUBLE_COMP_THRESHOLD);
-  device_.SetTime(3.0);
+  device_.SetTime(3.0, 3.0);
   EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
   EXPECT_NEAR(*node_1_temp_output, 22.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_2_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_3_temp_output, 20.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_4_temp_output, 20.666666666666, DOUBLE_COMP_THRESHOLD);
-  device_.SetTime(4.0);
+  device_.SetTime(4.0, 4.0);
   EXPECT_EQ(device_.Process(), fastcat::NO_FAULT);
   EXPECT_NEAR(*node_1_temp_output, 21.0, DOUBLE_COMP_THRESHOLD);
   EXPECT_NEAR(*node_2_temp_output, 22.0, DOUBLE_COMP_THRESHOLD);
@@ -176,7 +176,7 @@ TEST_F(ThreeNodeThermalModelTest, TempFault)
   *node_3_temp_input   = 20.0;
   *motor_current_input = 100.0;
   EXPECT_TRUE(device_.Read());
-  device_.SetTime(1.0);
+  device_.SetTime(1.0, 1.0);
   EXPECT_EQ(device_.Process(),
             fastcat::NO_FAULT);  // config allows one cycle of persistance
                                  // before faulting


### PR DESCRIPTION
Follow-on to https://github.com/nasa-jpl/fastcat/pull/89

Fixes use of simulation time for computing actuator behavior durations, which were still using the `jsd_time_get_time_sec` and `jsd_get_mono_time_sec` internally.

Adds new DeviceState field `monotonic_time`. If simulation mode is used, `time` and `monotonic_time` are both set to the provided simulation time. If not in a simulation, `time` uses Linux time (seconds since the epoch), and `monotonic_time` uses monotonic clock, (seconds since computer was switched on). Monotonic time is guaranteed to be monotonically increasing and therefore may be more reliable for computing durations, especially when computing short durations. 

Allow optionally passing in simulation time to device's `ConfigFromYAML` method to allow optionally passing in a startup time to a device.

Update logic to test for simulation time to:
```C++
if(external_time < 0) {
  // we are in online mode
} else {
  // we are in simulation
}
```
which allows passing in a zero value for initial start up time in simulation mode. 