### PR TITLE
Feat el2809 driver addition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG v2.3.8
+    GIT_TAG v2.3.9
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -14,6 +14,7 @@ For every `JSD Device` there is an `Offline Device` to emulate the behavior of t
 | El3162           | Beckhoff      | 2-channel 0-10v SE Analog Input           |
 | El3602           | Beckhoff      | 2-channel +/-10v Diff. Analog Input       |
 | El2124           | Beckhoff      | 4-channel 5v Digital Output               |
+| El2809           | Beckhoff      | 16-channel 28v Digital Output             |
 | El4102           | Beckhoff      | 2-channel 0-10v Analog Output             |
 | Ild1900          | Micro-Epsilon | Distance Laser Sensor                     |
 | AtiFts           | ATI           | Force-Torque Sensor                       |
@@ -411,6 +412,17 @@ The permitted range values are:
 ``` yaml
 - device_class: El2124
   name: el2124_1
+```
+
+## El2809 (16-channel 28v Digital Output)
+
+**The El2809 device has no configuration parameters**
+
+#### Example
+
+``` yaml
+- device_class: El2809
+  name: el2809_1
 ```
 
 ## El4102 (2-channel 0-10v Analog Output)

--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -14,7 +14,7 @@ For every `JSD Device` there is an `Offline Device` to emulate the behavior of t
 | El3162           | Beckhoff      | 2-channel 0-10v SE Analog Input           |
 | El3602           | Beckhoff      | 2-channel +/-10v Diff. Analog Input       |
 | El2124           | Beckhoff      | 4-channel 5v Digital Output               |
-| El2809           | Beckhoff      | 16-channel 28v Digital Output             |
+| El2809           | Beckhoff      | 16-channel 24v Digital Output             |
 | El4102           | Beckhoff      | 2-channel 0-10v Analog Output             |
 | Ild1900          | Micro-Epsilon | Distance Laser Sensor                     |
 | AtiFts           | ATI           | Force-Torque Sensor                       |

--- a/src/fcgen/fastcat_types.yaml
+++ b/src/fcgen/fastcat_types.yaml
@@ -314,6 +314,41 @@ states:
     - name: level_ch4
       type: uint8_t
 
+  - name: el2809
+    fields:
+    - name: level_ch1
+      type: uint8_t
+    - name: level_ch2
+      type: uint8_t
+    - name: level_ch3
+      type: uint8_t
+    - name: level_ch4
+      type: uint8_t
+    - name: level_ch5
+      type: uint8_t
+    - name: level_ch6
+      type: uint8_t
+    - name: level_ch7
+      type: uint8_t
+    - name: level_ch8
+      type: uint8_t
+    - name: level_ch9
+      type: uint8_t
+    - name: level_ch10
+      type: uint8_t
+    - name: level_ch11
+      type: uint8_t
+    - name: level_ch12
+      type: uint8_t
+    - name: level_ch13
+      type: uint8_t
+    - name: level_ch14
+      type: uint8_t
+    - name: level_ch15
+      type: uint8_t
+    - name: level_ch16
+      type: uint8_t
+
   - name: el4102
     fields:
     - name: voltage_output_ch1
@@ -680,6 +715,48 @@ commands:
     - name: channel_ch3
       type: uint8_t
     - name: channel_ch4
+      type: uint8_t
+
+  - name: el2809_write_channel
+    fields:
+    - name: channel
+      type: uint8_t
+    - name: level
+      type: uint8_t
+
+  - name: el2809_write_all_channels
+    fields:
+    - name: channel_ch1
+      type: uint8_t
+    - name: channel_ch2
+      type: uint8_t
+    - name: channel_ch3
+      type: uint8_t
+    - name: channel_ch4
+      type: uint8_t
+    - name: channel_ch5
+      type: uint8_t
+    - name: channel_ch6
+      type: uint8_t
+    - name: channel_ch7
+      type: uint8_t
+    - name: channel_ch8
+      type: uint8_t
+    - name: channel_ch9
+      type: uint8_t
+    - name: channel_ch10
+      type: uint8_t
+    - name: channel_ch11
+      type: uint8_t
+    - name: channel_ch12
+      type: uint8_t
+    - name: channel_ch13
+      type: uint8_t
+    - name: channel_ch14
+      type: uint8_t
+    - name: channel_ch15
+      type: uint8_t
+    - name: channel_ch16
       type: uint8_t
 
   - name: el4102_write_channel

--- a/src/jsd/el2809.cc
+++ b/src/jsd/el2809.cc
@@ -1,0 +1,117 @@
+// Include related header (for cc files)
+#include "fastcat/jsd/el2809.h"
+
+// Include c then c++ libraries
+#include <string.h>
+
+#include <cmath>
+#include <iostream>
+
+// Include external then project includes
+#include "fastcat/yaml_parser.h"
+
+fastcat::El2809::El2809()
+{
+  MSG_DEBUG("Constructed El2809");
+
+  state_       = std::make_shared<DeviceState>();
+  state_->type = EL2809_STATE;
+}
+
+bool fastcat::El2809::ConfigFromYaml(YAML::Node node)
+{
+  bool retval = ConfigFromYamlCommon(node);
+  jsd_set_slave_config((jsd_t*)context_, slave_id_, jsd_slave_config_);
+  return retval;
+}
+
+bool fastcat::El2809::ConfigFromYamlCommon(YAML::Node node)
+{
+  if (!ParseVal(node, "name", name_)) {
+    return false;
+  }
+  state_->name = name_;
+
+  jsd_slave_config_.configuration_active = true;
+  jsd_slave_config_.product_code         = JSD_EL2809_PRODUCT_CODE;
+  snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
+
+  return true;
+}
+
+bool fastcat::El2809::Read()
+{
+  const jsd_el2809_state_t* jsd_state =
+      jsd_el2809_get_state((jsd_t*)context_, slave_id_);
+
+  state_->el2809_state.level_ch1 = jsd_state->output[0];
+  state_->el2809_state.level_ch2 = jsd_state->output[1];
+  state_->el2809_state.level_ch3 = jsd_state->output[2];
+  state_->el2809_state.level_ch4 = jsd_state->output[3];
+  state_->el2809_state.level_ch5 = jsd_state->output[4];
+  state_->el2809_state.level_ch6 = jsd_state->output[5];
+  state_->el2809_state.level_ch7 = jsd_state->output[6];
+  state_->el2809_state.level_ch8 = jsd_state->output[7];
+  state_->el2809_state.level_ch9 = jsd_state->output[8];
+  state_->el2809_state.level_ch10 = jsd_state->output[9];
+  state_->el2809_state.level_ch11 = jsd_state->output[10];
+  state_->el2809_state.level_ch12 = jsd_state->output[11];
+  state_->el2809_state.level_ch13 = jsd_state->output[12];
+  state_->el2809_state.level_ch14 = jsd_state->output[13];
+  state_->el2809_state.level_ch15 = jsd_state->output[14];
+  state_->el2809_state.level_ch16 = jsd_state->output[15];
+
+  return true;
+}
+
+fastcat::FaultType fastcat::El2809::Process()
+{
+  jsd_el2809_process((jsd_t*)context_, slave_id_);
+  return NO_FAULT;
+}
+
+bool fastcat::El2809::Write(DeviceCmd& cmd)
+{
+  // If device supports async SDO requests
+  AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
+    return (sdoResult == SDO_RET_VAL_SUCCESS);
+  }
+
+  if (cmd.type == EL2809_WRITE_CHANNEL_CMD) {
+    uint8_t ch = cmd.el2809_write_channel_cmd.channel;
+    if (ch < 1 || ch > JSD_EL2809_NUM_CHANNELS) {
+      ERROR("Channel must be in range (1,%u)", JSD_EL2809_NUM_CHANNELS);
+      return false;
+    }
+
+    jsd_el2809_write_single_channel((jsd_t*)context_, slave_id_, ch - 1,
+                                    cmd.el2809_write_channel_cmd.level);
+
+  } else if (cmd.type == EL2809_WRITE_ALL_CHANNELS_CMD) {
+    uint8_t output_array[JSD_EL2809_NUM_CHANNELS] = {
+        cmd.el2809_write_all_channels_cmd.channel_ch1,
+        cmd.el2809_write_all_channels_cmd.channel_ch2,
+        cmd.el2809_write_all_channels_cmd.channel_ch3,
+        cmd.el2809_write_all_channels_cmd.channel_ch4,
+        cmd.el2809_write_all_channels_cmd.channel_ch5,
+        cmd.el2809_write_all_channels_cmd.channel_ch6,
+        cmd.el2809_write_all_channels_cmd.channel_ch7,
+        cmd.el2809_write_all_channels_cmd.channel_ch8,
+        cmd.el2809_write_all_channels_cmd.channel_ch9,
+        cmd.el2809_write_all_channels_cmd.channel_ch10,
+        cmd.el2809_write_all_channels_cmd.channel_ch11,
+        cmd.el2809_write_all_channels_cmd.channel_ch12,
+        cmd.el2809_write_all_channels_cmd.channel_ch13,
+        cmd.el2809_write_all_channels_cmd.channel_ch14,
+        cmd.el2809_write_all_channels_cmd.channel_ch15,
+        cmd.el2809_write_all_channels_cmd.channel_ch16};
+
+    jsd_el2809_write_all_channels((jsd_t*)context_, slave_id_, output_array);
+
+  } else {
+    ERROR("Bad EL2809 Command");
+    return false;
+  }
+  return true;
+}

--- a/src/jsd/el2809.h
+++ b/src/jsd/el2809.h
@@ -1,0 +1,32 @@
+#ifndef FASTCAT_EL2809_H_
+#define FASTCAT_EL2809_H_
+
+// Include related header (for cc files)
+
+// Include c then c++ libraries
+
+// Include external then project includes
+#include "fastcat/jsd/jsd_device_base.h"
+#include "jsd/jsd_el2809_pub.h"
+
+namespace fastcat
+{
+class El2809 : public JsdDeviceBase
+{
+ public:
+  El2809();
+  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      Read() override;
+  FaultType Process() override;
+  bool      Write(DeviceCmd& cmd) override;
+
+ protected:
+  bool ConfigFromYamlCommon(YAML::Node node);
+
+ private:
+  jsd_slave_config_t jsd_slave_config_ = {0};
+};
+
+}  // namespace fastcat
+
+#endif

--- a/src/jsd/el2809_offline.cc
+++ b/src/jsd/el2809_offline.cc
@@ -1,0 +1,148 @@
+// Include related header (for cc files)
+#include "fastcat/jsd/el2809_offline.h"
+
+// Include c then c++ libraries
+#include <string.h>
+
+#include <cmath>
+#include <iostream>
+
+// Include external then project includes
+#include "fastcat/yaml_parser.h"
+
+bool fastcat::El2809Offline::ConfigFromYaml(YAML::Node node)
+{
+  return ConfigFromYamlCommon(node);
+}
+
+bool fastcat::El2809Offline::Read() { return true; }
+
+fastcat::FaultType fastcat::El2809Offline::Process()
+{
+  return DeviceBase::Process();
+}
+
+bool fastcat::El2809Offline::Write(DeviceCmd& cmd)
+{
+  // If device supports async SDO requests
+  AsyncSdoRetVal sdoResult = WriteAsyncSdoRequest(cmd);
+  if (sdoResult != SDO_RET_VAL_NOT_APPLICABLE) {
+    return (sdoResult == SDO_RET_VAL_SUCCESS);
+  }
+
+  if (cmd.type == EL2809_WRITE_CHANNEL_CMD) {
+    uint8_t ch = cmd.el2809_write_channel_cmd.channel;
+    if (ch < 1 || ch > JSD_EL2809_NUM_CHANNELS) {
+      ERROR("Channel must be in range (1,%u)", JSD_EL2809_NUM_CHANNELS);
+      return false;
+    }
+    switch (cmd.el2809_write_channel_cmd.channel) {
+      case 1:
+        state_->el2809_state.level_ch1 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 2:
+        state_->el2809_state.level_ch2 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 3:
+        state_->el2809_state.level_ch3 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 4:
+        state_->el2809_state.level_ch4 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 5:
+        state_->el2809_state.level_ch5 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 6:
+        state_->el2809_state.level_ch6 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 7:
+        state_->el2809_state.level_ch7 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 8:
+        state_->el2809_state.level_ch8 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 9:
+        state_->el2809_state.level_ch9 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 10:
+        state_->el2809_state.level_ch10 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 11:
+        state_->el2809_state.level_ch11 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 12:
+        state_->el2809_state.level_ch12 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 13:
+        state_->el2809_state.level_ch13 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 14:
+        state_->el2809_state.level_ch14 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 15:
+        state_->el2809_state.level_ch15 = cmd.el2809_write_channel_cmd.level;
+        break;
+      case 16:
+        state_->el2809_state.level_ch16 = cmd.el2809_write_channel_cmd.level;
+        break;
+      default:
+        ERROR("Bad Channel value");
+        break;
+    }
+    return true;
+
+  } else if (cmd.type == EL2809_WRITE_ALL_CHANNELS_CMD) {
+    state_->el2809_state.level_ch1 =
+        cmd.el2809_write_all_channels_cmd.channel_ch1;
+
+    state_->el2809_state.level_ch2 =
+        cmd.el2809_write_all_channels_cmd.channel_ch2;
+
+    state_->el2809_state.level_ch3 =
+        cmd.el2809_write_all_channels_cmd.channel_ch3;
+
+    state_->el2809_state.level_ch4 =
+        cmd.el2809_write_all_channels_cmd.channel_ch4;
+
+    state_->el2809_state.level_ch5 =
+        cmd.el2809_write_all_channels_cmd.channel_ch5;
+
+    state_->el2809_state.level_ch6 =
+        cmd.el2809_write_all_channels_cmd.channel_ch6;
+
+    state_->el2809_state.level_ch7 =
+        cmd.el2809_write_all_channels_cmd.channel_ch7;
+
+    state_->el2809_state.level_ch8 =
+        cmd.el2809_write_all_channels_cmd.channel_ch8;
+
+    state_->el2809_state.level_ch9 =
+        cmd.el2809_write_all_channels_cmd.channel_ch9;
+
+    state_->el2809_state.level_ch10 =
+        cmd.el2809_write_all_channels_cmd.channel_ch10;
+
+    state_->el2809_state.level_ch11 =
+        cmd.el2809_write_all_channels_cmd.channel_ch11;
+
+    state_->el2809_state.level_ch12 =
+        cmd.el2809_write_all_channels_cmd.channel_ch12;
+
+    state_->el2809_state.level_ch13 =
+        cmd.el2809_write_all_channels_cmd.channel_ch13;
+
+    state_->el2809_state.level_ch14 =
+        cmd.el2809_write_all_channels_cmd.channel_ch14;
+
+    state_->el2809_state.level_ch15 =
+        cmd.el2809_write_all_channels_cmd.channel_ch15;
+
+    state_->el2809_state.level_ch16 =
+        cmd.el2809_write_all_channels_cmd.channel_ch16;
+
+  } else {
+    ERROR("Bad EL2809 Command");
+    return false;
+  }
+  return true;
+}

--- a/src/jsd/el2809_offline.h
+++ b/src/jsd/el2809_offline.h
@@ -1,0 +1,24 @@
+#ifndef FASTCAT_EL2809_OFFLINE_H_
+#define FASTCAT_EL2809_OFFLINE_H_
+
+// Include related header (for cc files)
+
+// Include c then c++ libraries
+
+// Include external then project includes
+#include "fastcat/jsd/el2809.h"
+
+namespace fastcat
+{
+class El2809Offline : public El2809
+{
+ public:
+  bool      ConfigFromYaml(YAML::Node node) override;
+  bool      Read() override;
+  FaultType Process() override;
+  bool      Write(DeviceCmd& cmd) override;
+};
+
+}  // namespace fastcat
+
+#endif


### PR DESCRIPTION
This PR adds in the necessary higher-level fastcat software to use the new EL2809 driver for 24V digital output.