### PR TITLE
feat: using different thermal masses for on/off motor states

### DIFF
--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -1300,4 +1300,6 @@ Where $C_{temp}$ represents the thermal coefficient of resistance, and $CM_{n}$ 
     request_signal_name:  output
   - observed_device_name: egd_1
     request_signal_name:  actual_current
+  - observed_device_name: egd_1
+    request_signal_name:  motor_on
 ```

--- a/doc/fastcat_device_config_parameters.md
+++ b/doc/fastcat_device_config_parameters.md
@@ -1241,7 +1241,8 @@ This example implements an absolute value function over the range of [-9, 9]
 
 | Parameter   | Description |
 | ----------- | ----------- |
-| thermal_mass_node_1      | The thermal mass that represents the winding node -- node 1 (J * kg / deg C) |
+| thermal_mass_node_1_on      | The thermal mass that represents the winding node -- node 1 (J * kg / deg C) when the motor is on (used to over-estimate how quickly heating occurs while running motor) |
+| thermal_mass_node_1_off      | The thermal mass that represents the winding node -- node 1 (J * kg / deg C) when the motor is off (used to under-estimate how quickly cooling occurs) |
 | thermal_mass_node_2      | The thermal mass that represents the stator node  -- node 2 (J * kg / deg C) |
 | thermal_res_nodes_1_to_2      | The effective thermal resistance between nodes 1 and 2 (deg C/W) |
 | thermal_res_nodes_2_to_3      | The effective thermal resistance between nodes 2 and 3 (deg C/W) |
@@ -1281,7 +1282,8 @@ Where $C_{temp}$ represents the thermal coefficient of resistance, and $CM_{n}$ 
 ``` yaml
 - device_class: ThreeNodeThermalModel
   name:         three_node_thermal_model_1 
-  thermal_mass_node_1: 1.0
+  thermal_mass_node_1_on: 0.8
+  thermal_mass_node_1_off: 1.0 
   thermal_mass_node_2: 2.0
   thermal_res_nodes_1_to_2: 3.0
   thermal_res_nodes_2_to_3: 4.0

--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -325,7 +325,8 @@ buses:
 
     - device_class: ThreeNodeThermalModel
       name:         three_node_thermal_model_1 
-      thermal_mass_node_1: 1.0
+      thermal_mass_node_1_on: 0.8
+      thermal_mass_node_1_off: 1.0
       thermal_mass_node_2: 2.0
       thermal_res_nodes_1_to_2: 3.0
       thermal_res_nodes_2_to_3: 4.0

--- a/example_configs/one_of_every_device_offline.yaml
+++ b/example_configs/one_of_every_device_offline.yaml
@@ -343,5 +343,7 @@ buses:
         request_signal_name:  output
       - observed_device_name: egd_1
         request_signal_name:  actual_current
+      - observed_device_name: egd_1
+        request_signal_name:  motor_on
 
 

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -17,7 +17,11 @@ bool ThreeNodeThermalModel::ConfigFromYaml(YAML::Node node)
   }
   state_->name = name_;
 
-  if (!ParseVal(node, "thermal_mass_node_1", thermal_mass_node_1_)) {
+  if (!ParseVal(node, "thermal_mass_node_1_on", thermal_mass_node_1_on_)) {
+    return false;
+  }
+
+  if (!ParseVal(node, "thermal_mass_node_1_off", thermal_mass_node_1_off_)) {
     return false;
   }
 
@@ -123,6 +127,7 @@ bool ThreeNodeThermalModel::Read()
   node_temps_[2] = exp_smoothing_alpha_ * node_3_temp_sample + (1.0 - exp_smoothing_alpha_) * node_temps_[2];
 
   motor_current_ = signals_[MOTOR_CURRENT_IDX].value;
+  motor_on_status_ = signals_[MOTOR_ON_STATUS_IDX].value;
   return true;
 }
 
@@ -139,8 +144,10 @@ FaultType ThreeNodeThermalModel::Process()
   double q_node_2_to_3 =
       (node_temps_[1] - node_temps_[2]) / thermal_res_nodes_2_to_3_;
   // calculate temperatures
+  double thermal_mass_node_1 = motor_on_status_ ? thermal_mass_node_1_on_ : thermal_mass_node_1_off_;
+
   node_temps_[0] += (q_in - q_node_1_to_2) *
-                    ((state_->time - last_time_) / thermal_mass_node_1_);
+                    ((state_->time - last_time_) / thermal_mass_node_1);
   node_temps_[1] += (q_node_1_to_2 - q_node_2_to_3) *
                     ((state_->time - last_time_) / thermal_mass_node_2_);
   node_temps_[3] =

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -59,7 +59,8 @@ class ThreeNodeThermalModel : public DeviceBase
 
  protected:
   // declare motor parameters
-  double thermal_mass_node_1_{0.0};
+  double thermal_mass_node_1_on_{0.0};
+  double thermal_mass_node_1_off_{0.0};
   double thermal_mass_node_2_{0.0};
   double thermal_res_nodes_1_to_2_{
       0.0};  ///< thermal resistance from node 1 to 2 (deg C / W)
@@ -103,11 +104,13 @@ class ThreeNodeThermalModel : public DeviceBase
 
   // constants
   // the required number of signals for this device
-  static constexpr size_t FC_TNTM_NUM_SIGNALS = 2;
+  static constexpr size_t FC_TNTM_NUM_SIGNALS = 3;
   // signal index for node 3 temperature
   static constexpr size_t NODE_3_TEMP_IDX = 0;
   // signal index for motor current
   static constexpr size_t MOTOR_CURRENT_IDX = 1;
+  // signal index for motor on status (from the actuator state)
+  static constexpr size_t MOTOR_ON_STATUS_IDX = 2;
 };
 }  // namespace fastcat
 

--- a/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_signals.yaml
+++ b/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_signals.yaml
@@ -1,6 +1,7 @@
 device_class: ThreeNodeThermalModel
 name:         three_node_thermal_model_1 
-thermal_mass_node_1: 1.0
+thermal_mass_node_1_on: 0.8
+thermal_mass_node_1_off: 1.0
 thermal_mass_node_2: 2.0
 thermal_res_nodes_1_to_2: 3.0
 thermal_res_nodes_2_to_3: 4.0

--- a/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_temps.yaml
+++ b/test/test_unit/test_three_node_thermal_model_yamls/invalid_num_temps.yaml
@@ -1,6 +1,7 @@
 device_class: ThreeNodeThermalModel
 name:         three_node_thermal_model_1 
-thermal_mass_node_1: 1.0
+thermal_mass_node_1_on: 0.8
+thermal_mass_node_1_off: 1.0
 thermal_mass_node_2: 2.0
 thermal_res_nodes_1_to_2: 3.0
 thermal_res_nodes_2_to_3: 4.0

--- a/test/test_unit/test_three_node_thermal_model_yamls/valid.yaml
+++ b/test/test_unit/test_three_node_thermal_model_yamls/valid.yaml
@@ -1,6 +1,7 @@
 device_class: ThreeNodeThermalModel
 name:         three_node_thermal_model_1 
-thermal_mass_node_1: 1.0
+thermal_mass_node_1_on: 0.8
+thermal_mass_node_1_off: 1.0
 thermal_mass_node_2: 1.0
 thermal_res_nodes_1_to_2: 1.0
 thermal_res_nodes_2_to_3: 1.0


### PR DESCRIPTION
This modification to the thermal model allows one to have separate thermal masses for when the motor is on or off. This is one method of being conservative in estimating the heat-up/ cool-down of the motor.