### PR TITLE
Updates Fastcat for JSD release v3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ find_package(YamlCpp REQUIRED 0.6.3)
 include(FetchContent)
 FetchContent_Declare(jsd
     GIT_REPOSITORY https://github.com/nasa-jpl/jsd.git
-    GIT_TAG v2.3.10
+    GIT_TAG v3.0.0
     )
 FetchContent_MakeAvailable(jsd)
 

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -14,7 +14,7 @@
 #include "fastcat/yaml_parser.h"
 #include "jsd/jsd.h"
 #include "jsd/jsd_egd_pub.h"
-#include "jsd/jsd_epd_pub.h"
+#include "jsd/jsd_epd_nominal_pub.h"
 
 fastcat::Actuator::Actuator()
 {
@@ -749,7 +749,7 @@ std::string fastcat::Actuator::GetJSDFaultCodeAsString(const DeviceState& state)
   } else if (state.type == PLATINUM_ACTUATOR_STATE) {
     auto fault = static_cast<jsd_epd_fault_code_t>(
         state.platinum_actuator_state.jsd_fault_code);
-    fault_str = std::string(jsd_epd_fault_code_to_string(fault));
+    fault_str = std::string(jsd_epd_nominal_fault_code_to_string(fault));
   } else {
     fault_str = "State is not an Elmo actuator type.";
   }

--- a/src/jsd/ati_fts.cc
+++ b/src/jsd/ati_fts.cc
@@ -23,7 +23,7 @@ bool fastcat::AtiFts::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_ATI_FTS_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_ATI_FTS;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   uint32_t cal;

--- a/src/jsd/egd.cc
+++ b/src/jsd/egd.cc
@@ -138,7 +138,7 @@ bool fastcat::Egd::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EGD_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EGD;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   if (!ParseVal(node, "drive_cmd_mode", drive_cmd_mode_string_)) {

--- a/src/jsd/el1008.cc
+++ b/src/jsd/el1008.cc
@@ -29,7 +29,7 @@ bool fastcat::El1008::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL1008_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL1008;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   return true;

--- a/src/jsd/el2124.cc
+++ b/src/jsd/el2124.cc
@@ -33,7 +33,7 @@ bool fastcat::El2124::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL2124_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL2124;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   return true;

--- a/src/jsd/el2809.cc
+++ b/src/jsd/el2809.cc
@@ -33,7 +33,7 @@ bool fastcat::El2809::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL2809_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL2809;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   return true;

--- a/src/jsd/el3104.cc
+++ b/src/jsd/el3104.cc
@@ -33,7 +33,7 @@ bool fastcat::El3104::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL3104_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL3104;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   return true;

--- a/src/jsd/el3162.cc
+++ b/src/jsd/el3162.cc
@@ -29,7 +29,7 @@ bool fastcat::El3162::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL3162_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL3162;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   return true;

--- a/src/jsd/el3202.cc
+++ b/src/jsd/el3202.cc
@@ -33,7 +33,7 @@ bool fastcat::El3202::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL3202_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL3202;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   if (!ParseVal(node, "element_ch1", element_ch1_string_)) {

--- a/src/jsd/el3208.cc
+++ b/src/jsd/el3208.cc
@@ -43,7 +43,7 @@ bool fastcat::El3208::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL3208_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL3208;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   // Parse element array

--- a/src/jsd/el3318.cc
+++ b/src/jsd/el3318.cc
@@ -33,7 +33,7 @@ bool fastcat::El3318::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL3318_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL3318;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   if (!ParseVal(node, "element", element_string_)) {

--- a/src/jsd/el3602.cc
+++ b/src/jsd/el3602.cc
@@ -33,7 +33,7 @@ bool fastcat::El3602::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL3602_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL3602;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   if (!ParseVal(node, "range_ch1", range_ch1_string_)) {

--- a/src/jsd/el4102.cc
+++ b/src/jsd/el4102.cc
@@ -33,7 +33,7 @@ bool fastcat::El4102::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_EL4102_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_EL4102;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   return true;

--- a/src/jsd/gold_actuator.cc
+++ b/src/jsd/gold_actuator.cc
@@ -12,7 +12,7 @@ fastcat::GoldActuator::GoldActuator() { state_->type = GOLD_ACTUATOR_STATE; }
 
 void fastcat::GoldActuator::PopulateJsdSlaveConfig()
 {
-  jsd_slave_config_.product_code = JSD_EGD_PRODUCT_CODE;
+  jsd_slave_config_.driver_type = JSD_DRIVER_TYPE_EGD;
 
   jsd_slave_config_.egd.drive_cmd_mode = JSD_EGD_DRIVE_CMD_MODE_CS;
   jsd_slave_config_.egd.max_motor_speed =

--- a/src/jsd/ild1900.cc
+++ b/src/jsd/ild1900.cc
@@ -29,7 +29,7 @@ bool fastcat::Ild1900::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_ILD1900_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_ILD1900;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   std::string model_string;

--- a/src/jsd/jed0101.cc
+++ b/src/jsd/jed0101.cc
@@ -30,7 +30,7 @@ bool fastcat::Jed0101::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_JED0101_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_JED0101;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   if (!ParseVal(node, "initial_cmd", initial_cmd_)) {

--- a/src/jsd/jed0200.cc
+++ b/src/jsd/jed0200.cc
@@ -30,7 +30,7 @@ bool fastcat::Jed0200::ConfigFromYamlCommon(YAML::Node node)
   state_->name = name_;
 
   jsd_slave_config_.configuration_active = true;
-  jsd_slave_config_.product_code         = JSD_JED0200_PRODUCT_CODE;
+  jsd_slave_config_.driver_type          = JSD_DRIVER_TYPE_JED0200;
   snprintf(jsd_slave_config_.name, JSD_NAME_LEN, "%s", name_.c_str());
 
   if (!ParseVal(node, "initial_cmd", initial_cmd_)) {

--- a/src/jsd/platinum_actuator.h
+++ b/src/jsd/platinum_actuator.h
@@ -7,7 +7,7 @@
 
 // Include external then project includes
 #include "fastcat/jsd/actuator.h"
-#include "jsd/jsd_epd_pub.h"
+#include "jsd/jsd_epd_nominal_pub.h"
 
 namespace fastcat
 {
@@ -17,7 +17,7 @@ class PlatinumActuator : public Actuator
   PlatinumActuator();
 
  protected:
-  jsd_epd_state_t jsd_epd_state_ = {};
+  jsd_epd_nominal_state_t jsd_epd_state_ = {};
 
  private:
   void PopulateJsdSlaveConfig() override;

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -14,7 +14,7 @@ fastcat::PlatinumActuatorOffline::PlatinumActuatorOffline()
 {
   MSG_DEBUG("Constructed PlatinumActuatorOffline");
 
-  memset(&jsd_epd_state_, 0, sizeof(jsd_epd_state_t));
+  memset(&jsd_epd_state_, 0, sizeof(jsd_epd_nominal_state_t));
   motor_on_start_time_ = jsd_time_get_time_sec();
 }
 


### PR DESCRIPTION
Updates Fastcat to accommodate the changes of JSD release v3.0.0 which are not backward compatible.

The changes in JSD consisted in replacing the product code field in driver configurations with a driver type field, and renaming the EPD driver (added `nominal` suffix after `epd`) given that there are now two variations of the driver, nominal and SIL.