### PR TITLE
Fixes initialization bug in Elmo Platinum's offline driver

### DIFF
--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -14,6 +14,7 @@ fastcat::PlatinumActuatorOffline::PlatinumActuatorOffline()
 {
   MSG_DEBUG("Constructed PlatinumActuatorOffline");
   memset(&jsd_epd_state_, 0, sizeof(jsd_epd_nominal_state_t));
+  jsd_epd_state_.fault_code = JSD_EPD_FAULT_OKAY;
 }
 
 bool fastcat::PlatinumActuatorOffline::ConfigFromYaml(const YAML::Node& node)


### PR DESCRIPTION
Explicitly initializes the fault_code member of the internal JSD driver's state.

Test Plan:
Tested by @Bouty92 on local Fastcat deployment.