### PR TITLE
Removing the fault condition if we are in quick stop active

### DIFF
--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -547,9 +547,8 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
     return true;
   }
   auto elmo_state_machine_state = GetElmoStateMachineState();
+  
   if (elmo_state_machine_state ==
-          JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE ||
-      elmo_state_machine_state ==
           JSD_ELMO_STATE_MACHINE_STATE_FAULT_REACTION_ACTIVE ||
       elmo_state_machine_state == JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
     ERROR("%s: Elmo drive state machine state is off nominal", name_.c_str());

--- a/src/jsd/platinum_actuator.cc
+++ b/src/jsd/platinum_actuator.cc
@@ -129,10 +129,8 @@ bool fastcat::PlatinumActuator::HandleNewProfPosCmdImpl(const DeviceCmd& cmd)
 {
   // Save the command so that it can be sent continuously until the drive
   // acknowledges its reception.
-  last_cmd_ = cmd;
-
   TransitionToState(ACTUATOR_SMS_PROF_POS_DISENGAGING);
-
+  last_cmd_ = cmd;
   return true;
 }
 


### PR DESCRIPTION
Removing the use of quick stop active as an indicator of a fault status. This is not true as move commands go into ACTUATOR_SMS_HOLDING which eventually goes in ACTUATOR_SMS_HALTED.
Once there, a new command calls CheckStateMachineMotionCmds() which gets out of halted using ElmoReset().