### PR TITLE
Switching to using last time and current time for velocity calculation

### DIFF
--- a/src/device_base.cc
+++ b/src/device_base.cc
@@ -27,6 +27,7 @@ void fastcat::DeviceBase::SetLoopPeriod(double loop_period)
 
 void fastcat::DeviceBase::SetTime(double time, double monotonic_time)
 {
+  last_time_             = state_->monotonic_time;
   state_->time           = time;
   state_->monotonic_time = monotonic_time;
 }

--- a/src/device_base.cc
+++ b/src/device_base.cc
@@ -27,7 +27,7 @@ void fastcat::DeviceBase::SetLoopPeriod(double loop_period)
 
 void fastcat::DeviceBase::SetTime(double time, double monotonic_time)
 {
-  last_time_             = state_->monotonic_time;
+  last_monotonic_time_             = state_->monotonic_time;
   state_->time           = time;
   state_->monotonic_time = monotonic_time;
 }

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -48,6 +48,7 @@ class DeviceBase
  protected:
   std::string name_;  ///< unique device name
 
+  double last_time_                         = 0.0;
   double loop_period_                       = 0.0;  ///< only some devices need
   double initialization_time_sec_           = -1;   ///< only some devices need
   double monotonic_initialization_time_sec_ = -1;   ///< only some devices need

--- a/src/device_base.h
+++ b/src/device_base.h
@@ -48,7 +48,7 @@ class DeviceBase
  protected:
   std::string name_;  ///< unique device name
 
-  double last_time_                         = 0.0;
+  double last_monotonic_time_               = 0.0;
   double loop_period_                       = 0.0;  ///< only some devices need
   double initialization_time_sec_           = -1;   ///< only some devices need
   double monotonic_initialization_time_sec_ = -1;   ///< only some devices need

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -169,7 +169,6 @@ FaultType ThreeNodeThermalModel::Process()
   state_->three_node_thermal_model_state.node_2_temp = node_temps_[1];
   state_->three_node_thermal_model_state.node_3_temp = node_temps_[2];
   state_->three_node_thermal_model_state.node_4_temp = node_temps_[3];
-  last_time_ = state_->time;  // update loop time
 
   return NO_FAULT;
 }

--- a/src/fastcat_devices/three_node_thermal_model.cc
+++ b/src/fastcat_devices/three_node_thermal_model.cc
@@ -7,7 +7,6 @@ ThreeNodeThermalModel::ThreeNodeThermalModel()
 {
   state_       = std::make_shared<DeviceState>();
   state_->type = THREE_NODE_THERMAL_MODEL_STATE;
-  last_time_   = jsd_time_get_time_sec();  // init time
 }
 
 bool ThreeNodeThermalModel::ConfigFromYaml(const YAML::Node& node)
@@ -146,9 +145,9 @@ FaultType ThreeNodeThermalModel::Process()
   double thermal_mass_node_1 = motor_on_status_ ? thermal_mass_node_1_on_ : thermal_mass_node_1_off_;
 
   node_temps_[0] += (q_in - q_node_1_to_2) *
-                    ((state_->time - last_time_) / thermal_mass_node_1);
+                    ((state_->monotonic_time - last_monotonic_time_) / thermal_mass_node_1);
   node_temps_[1] += (q_node_1_to_2 - q_node_2_to_3) *
-                    ((state_->time - last_time_) / thermal_mass_node_2_);
+                    ((state_->monotonic_time - last_monotonic_time_) / thermal_mass_node_2_);
   node_temps_[3] =
       (k1_ * node_temps_[0] + k2_ * node_temps_[1] + k3_ * node_temps_[2]) /
       (k1_ + k2_ + k3_);

--- a/src/fastcat_devices/three_node_thermal_model.h
+++ b/src/fastcat_devices/three_node_thermal_model.h
@@ -101,9 +101,6 @@ class ThreeNodeThermalModel : public DeviceBase
       0, 0, 0, 0};  ///< this is used as a counter for how many cycles node 1
                     ///< has been over the temperature limit
 
-  // tracked variables
-  double last_time_{0.0};
-
   // constants
   // the required number of signals for this device
   static constexpr size_t FC_TNTM_NUM_SIGNALS = 3;

--- a/src/jsd/gold_actuator_offline.cc
+++ b/src/jsd/gold_actuator_offline.cc
@@ -136,7 +136,7 @@ void fastcat::GoldActuatorOffline::ElmoCSP(
   // Perform numerical differencing of position to get actual_velocity
   double vel = (jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position -
                 jsd_egd_state_.actual_position) /
-               loop_period_;
+               (state_->monotonic_time - last_time_);
 
   // simulate actual position, current and velocity
   jsd_egd_state_.actual_position =
@@ -163,7 +163,7 @@ void fastcat::GoldActuatorOffline::ElmoCSV(
   jsd_egd_state_.actual_current =
       jsd_egd_state_.cmd_current + jsd_egd_state_.cmd_ff_current;
   jsd_egd_state_.actual_position +=
-      jsd_egd_state_.actual_velocity * loop_period_;  // integrated
+      jsd_egd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
 }
 
 void fastcat::GoldActuatorOffline::ElmoCST(
@@ -187,5 +187,5 @@ void fastcat::GoldActuatorOffline::ElmoCST(
       jsd_egd_state_.actual_current / params_.continuous_current_limit_amps;
   jsd_egd_state_.actual_velocity = pct * params_.max_speed_eu_per_sec;
   jsd_egd_state_.actual_position +=
-      jsd_egd_state_.actual_velocity * loop_period_;  // integrated
+      jsd_egd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
 }

--- a/src/jsd/gold_actuator_offline.cc
+++ b/src/jsd/gold_actuator_offline.cc
@@ -136,7 +136,7 @@ void fastcat::GoldActuatorOffline::ElmoCSP(
   // Perform numerical differencing of position to get actual_velocity
   double vel = (jsd_egd_state_.cmd_position + jsd_egd_state_.cmd_ff_position -
                 jsd_egd_state_.actual_position) /
-               (state_->monotonic_time - last_time_);
+               (state_->monotonic_time - last_monotonic_time_);
 
   // simulate actual position, current and velocity
   jsd_egd_state_.actual_position =
@@ -163,7 +163,7 @@ void fastcat::GoldActuatorOffline::ElmoCSV(
   jsd_egd_state_.actual_current =
       jsd_egd_state_.cmd_current + jsd_egd_state_.cmd_ff_current;
   jsd_egd_state_.actual_position +=
-      jsd_egd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
+      jsd_egd_state_.actual_velocity * (state_->monotonic_time - last_monotonic_time_);  // integrated
 }
 
 void fastcat::GoldActuatorOffline::ElmoCST(
@@ -187,5 +187,5 @@ void fastcat::GoldActuatorOffline::ElmoCST(
       jsd_egd_state_.actual_current / params_.continuous_current_limit_amps;
   jsd_egd_state_.actual_velocity = pct * params_.max_speed_eu_per_sec;
   jsd_egd_state_.actual_position +=
-      jsd_egd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
+      jsd_egd_state_.actual_velocity * (state_->monotonic_time - last_monotonic_time_);  // integrated
 }

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -387,7 +387,7 @@ void fastcat::PlatinumActuatorOffline::ElmoCSP(
   // Differentiate position to get actual_velocity
   double vel = (jsd_epd_state_.cmd_position + jsd_epd_state_.cmd_ff_position -
                 jsd_epd_state_.actual_position) /
-               loop_period_;
+               (state_->monotonic_time - last_time_);
 
   // simulate actuals
   jsd_epd_state_.actual_position =
@@ -415,7 +415,7 @@ void fastcat::PlatinumActuatorOffline::ElmoCSV(
   jsd_epd_state_.actual_current =
       jsd_epd_state_.cmd_current + jsd_epd_state_.cmd_ff_current;
   jsd_epd_state_.actual_position +=
-      jsd_epd_state_.actual_velocity * loop_period_;  // integrated
+      jsd_epd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
 }
 
 void fastcat::PlatinumActuatorOffline::ElmoCST(
@@ -440,5 +440,5 @@ void fastcat::PlatinumActuatorOffline::ElmoCST(
   jsd_epd_state_.actual_velocity =
       pct * params_.max_speed_eu_per_sec;  // sure, why not
   jsd_epd_state_.actual_position +=
-      jsd_epd_state_.actual_velocity * loop_period_;  // integrated
+      jsd_epd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
 }

--- a/src/jsd/platinum_actuator_offline.cc
+++ b/src/jsd/platinum_actuator_offline.cc
@@ -387,7 +387,7 @@ void fastcat::PlatinumActuatorOffline::ElmoCSP(
   // Differentiate position to get actual_velocity
   double vel = (jsd_epd_state_.cmd_position + jsd_epd_state_.cmd_ff_position -
                 jsd_epd_state_.actual_position) /
-               (state_->monotonic_time - last_time_);
+               (state_->monotonic_time - last_monotonic_time_);
 
   // simulate actuals
   jsd_epd_state_.actual_position =
@@ -415,7 +415,7 @@ void fastcat::PlatinumActuatorOffline::ElmoCSV(
   jsd_epd_state_.actual_current =
       jsd_epd_state_.cmd_current + jsd_epd_state_.cmd_ff_current;
   jsd_epd_state_.actual_position +=
-      jsd_epd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
+      jsd_epd_state_.actual_velocity * (state_->monotonic_time - last_monotonic_time_);  // integrated
 }
 
 void fastcat::PlatinumActuatorOffline::ElmoCST(
@@ -440,5 +440,5 @@ void fastcat::PlatinumActuatorOffline::ElmoCST(
   jsd_epd_state_.actual_velocity =
       pct * params_.max_speed_eu_per_sec;  // sure, why not
   jsd_epd_state_.actual_position +=
-      jsd_epd_state_.actual_velocity * (state_->monotonic_time - last_time_);  // integrated
+      jsd_epd_state_.actual_velocity * (state_->monotonic_time - last_monotonic_time_);  // integrated
 }


### PR DESCRIPTION
Added changes to the platinum and gold drive offline modes to have more accurate velocity calculation.
Before this MR, velocity was calculated using the loop period which may be inaccurate due to jitter. Now the velocity is calculated using the prior process loop time and the current process loop time.