### PR TITLE
Switching to finding cog on the system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,11 @@
 ####### Fastcat COG Autocoding #######
+find_program(COG NAMES cog cogapp)
+
 add_custom_command(
     OUTPUT
     ${CMAKE_BINARY_DIR}/include/fastcat/types.h
     COMMAND
-    cog -d -D cog_yaml_file=fcgen/fastcat_types.yaml
+    ${COG} -d -D cog_yaml_file=fcgen/fastcat_types.yaml
     -o ${CMAKE_BINARY_DIR}/include/fastcat/types.h
     ${CMAKE_CURRENT_LIST_DIR}/fcgen/types.h.cog
     DEPENDS
@@ -20,7 +22,7 @@ add_custom_command(
     OUTPUT
     ${CMAKE_BINARY_DIR}/fastcat/autogen/signal_handling.cc
     COMMAND
-    cog -d -D cog_yaml_file=fcgen/fastcat_types.yaml
+    ${COG} -d -D cog_yaml_file=fcgen/fastcat_types.yaml
     -o ${CMAKE_BINARY_DIR}/fastcat/autogen/signal_handling.cc
     ${CMAKE_CURRENT_LIST_DIR}/fcgen/signal_handling.cc.cog
     DEPENDS
@@ -37,7 +39,7 @@ add_custom_command(
     OUTPUT
     ${CMAKE_BINARY_DIR}/fastcat/autogen/fastcat_devices/commander.cc
     COMMAND
-    cog -d -D cog_yaml_file=fcgen/fastcat_types.yaml
+    ${COG} -d -D cog_yaml_file=fcgen/fastcat_types.yaml
     -o ${CMAKE_BINARY_DIR}/fastcat/autogen/fastcat_devices/commander.cc
     ${CMAKE_CURRENT_LIST_DIR}/fcgen/commander.cc.cog
     DEPENDS


### PR DESCRIPTION
Ubuntu 24 cogapp is named "cogapp" and not "cog" so this build fails on newer systems.