### PR TITLE
Modifying SaveActuatorPosFile to only save when map is not empty

### DIFF
--- a/src/manager.cc
+++ b/src/manager.cc
@@ -1202,6 +1202,11 @@ void fastcat::Manager::SaveActuatorPosFile()
     WARNING("Could not move: %s, file may not exist", pos_file.c_str());
   }
 
+  if (actuator_pos_map_.empty()) {
+    WARNING("Actuator position map is empty, skipping save to: %s", pos_file.c_str());
+    return;
+  }
+
   YAML::Node file_node;
   for (auto pos_pair = actuator_pos_map_.begin();
        pos_pair != actuator_pos_map_.end(); ++pos_pair) {


### PR DESCRIPTION
Adding a quick check that ensures we do not try to create a saved positions file if there is no information to be saved. Therefore, there will not be an issue during the next FCAT node startup if you choose to not fail on missing pos file.