### PR TITLE
Fix #134 by adding an atomic try_pop and using it in WriteCommands

### DIFF
--- a/src/manager.cc
+++ b/src/manager.cc
@@ -778,10 +778,8 @@ bool fastcat::Manager::ConfigOfflineBusFromYaml(const YAML::Node& node,
 
 bool fastcat::Manager::WriteCommands()
 {
-  while (!cmd_queue_->empty()) {
-    DeviceCmd cmd = cmd_queue_->front();
-    cmd_queue_->pop();
-
+  DeviceCmd cmd;
+  while (cmd_queue_->try_pop(cmd)) {
     auto find_pair = device_map_.find(cmd.name);
 
     if (find_pair == device_map_.end()) {

--- a/src/thread_safe_queue.h
+++ b/src/thread_safe_queue.h
@@ -36,6 +36,17 @@ public:
     std::lock_guard<std::mutex> lock(m);
 		return q.empty();
   }
+
+  bool try_pop(T& item)
+  {
+    std::lock_guard<std::mutex> lock(m);
+    if (q.empty()) {
+      return false;
+    }
+    item = q.front();
+    q.pop();
+    return true;
+  }
   
 
 private:


### PR DESCRIPTION
Addresses #134

The underlying issue is that `src/manager.cc fastcat::Manager::WriteCommands()` does the queue check and queue pop as two separate atomic operations instead of as one. This creates a vulnerability where if more than one thread `WriteCommands`, it can lead to undefined behavior.

The fix is to add try_pop which makes an atomic operation out of checking if the queue is empty and popping an element from the queue if it's not empty.
