### PR TITLE
Addresses #30 

### DIFF
--- a/src/manager.h
+++ b/src/manager.h
@@ -92,7 +92,8 @@ class Manager
   /** @brief Returns list of device state pointers
    *
    *  Provided for potential optimization. GetDeviceStates() generally performs
-   * better.
+   *  better. This function is not intended to be called in a realtime process loop
+   *  because it dynamically allocates memory to hold a vector of device state pointers.
    *  @return device states
    */
   std::vector<std::shared_ptr<const DeviceState>> GetDeviceStatePointers();


### PR DESCRIPTION
Added warning to docstring about not using GetDeviceStatePointers in a realtime loop instead of making any code changes.
Closes #30

We declined to make any code change because we are still following the philosophy here. But we added a warning to the function so that other users won't abuse the API and risk manifesting the scenario @d-loret spoke of

>The idea behind this function is to get fixed, shared pointers to device state data and that it would be called once by the application. Once the application has this array of pointer, it doesn't need to call this again and can just dereference it as needed to get the current state data.