### PR TITLE
Split init

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ while (running) {
 
 **Note:** The `Process()` loop must maintain the target loop rate specified in your YAML configuration to prevent EtherCAT watchdog timeouts. 
 
-It is always recommend you specify your dependency to a tagged release (e.g. `GIT_TAG v0.13.13`) so updates to master cannot break your build (NOT `GIT_TAG master`). 
-
 ### Semantic Versioning
 
 fastcat uses Semantic versioning to help applications reason about the software as updates are continuously rolled out. Tailored to fastcat, the Semver rules are as follows:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,72 @@ FetchContent_Declare(fastcat
 FetchContent_MakeAvailable(fastcat)
 ```
 
-It is always recommend you specify your dependency to a tagged reldroppingease (`GIT_TAG v0.4.3`) so updates to master cannot break your build (NOT `GIT_TAG master`). 
+It is always recommend you specify your dependency to a tagged release (`GIT_TAG v0.4.3`) so updates to master cannot break your build (NOT `GIT_TAG master`).
+
+### Manager API Usage
+
+Fastcat provides two initialization patterns to accommodate different application architectures:
+
+#### Standard Initialization (Single-Phase)
+
+For simple applications, use `ConfigFromYaml()` which handles both configuration parsing and hardware initialization:
+
+```cpp
+#include "fastcat/manager.h"
+
+fastcat::Manager manager;
+YAML::Node node = YAML::LoadFile("config.yaml");
+
+if (!manager.ConfigFromYaml(node)) {
+    // Handle error
+    return false;
+}
+
+// Manager is ready - start your control loop
+while (running) {
+    manager.Process();
+}
+```
+
+#### Split Initialization (Two-Phase)
+
+For applications that need to perform time-consuming operations between configuration parsing and hardware initialization (e.g., ROS node setup), use the split API to prevent EtherCAT watchdog timeouts:
+
+```cpp
+#include "fastcat/manager.h"
+
+fastcat::Manager manager;
+YAML::Node node = YAML::LoadFile("config.yaml");
+
+// Phase 1: Parse YAML and create device objects (no hardware init)
+if (!manager.CreateConfigFromYaml(node)) {
+    // Handle error
+    return false;
+}
+
+// Perform time-consuming setup operations here
+// Example: Create ROS publishers, subscribers, services, etc.
+// This won't cause EtherCAT slaves to timeout because they're not yet in OP state
+
+// Phase 2: Initialize EtherCAT hardware and transition slaves to OP state
+if (!manager.InitHardware()) {
+    // Handle error
+    return false;
+}
+
+// IMPORTANT: Start your control loop immediately after InitHardware()
+// to prevent SM watchdog timeouts (~100ms)
+while (running) {
+    manager.Process();
+}
+```
+
+**When to use split initialization:**
+- Your application performs time-consuming setup (>50ms) after configuration
+- You're integrating with frameworks that have initialization overhead (ROS, middleware, etc.)
+- You need to query device information before hardware initialization
+
+**Note:** The `Process()` loop must maintain the target loop rate specified in your YAML configuration to prevent EtherCAT watchdog timeouts. 
 
 ### Semantic Versioning
 

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -208,6 +208,20 @@ bool fastcat::Manager::ConfigFromYaml(const YAML::Node& node,
   }
   SUCCESS("Configured Signals.");
 
+  return true;
+}
+
+bool fastcat::Manager::InitHardware()
+{
+  for (auto& p : pending_jsd_inits_) {
+    if (!jsd_init(p.jsd, p.ifname.c_str(), p.enable_autorecovery,
+                  1.0e6 / target_loop_rate_hz_)) {
+      ERROR("Failed to initialize JSD bus: %s", p.ifname.c_str());
+      return false;
+    }
+  }
+  pending_jsd_inits_.clear();
+
   MSG("Reading initial state of all devices.");
   // Empirically observed some EGDs require at least one valid PDO write
   //   before reporting valid actual encoder positions after startup.
@@ -559,7 +573,8 @@ bool fastcat::Manager::ConfigJSDBusFromYaml(const YAML::Node& node,
     jsd_device_list_.push_back(jsdDevice);
   }
 
-  return jsd_init(jsd, ifname.c_str(), enable_ar, 1.0e6 / target_loop_rate_hz_);
+  pending_jsd_inits_.push_back({ifname, jsd, enable_ar});
+  return true;
 }
 
 bool fastcat::Manager::ConfigFastcatBusFromYaml(const YAML::Node& node,

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -97,8 +97,8 @@ void fastcat::Manager::Shutdown()
   SaveActuatorPosFile();
 }
 
-bool fastcat::Manager::ConfigFromYaml(const YAML::Node& node,
-                                      double            external_time)
+bool fastcat::Manager::CreateConfigFromYaml(const YAML::Node& node,
+                                            double            external_time)
 {
   // Configure Fastcat Parameters
   YAML::Node fastcat_node;
@@ -209,6 +209,15 @@ bool fastcat::Manager::ConfigFromYaml(const YAML::Node& node,
   SUCCESS("Configured Signals.");
 
   return true;
+}
+
+bool fastcat::Manager::ConfigFromYaml(const YAML::Node& node,
+                                      double            external_time)
+{
+  if (!CreateConfigFromYaml(node, external_time)) {
+    return false;
+  }
+  return InitHardware();
 }
 
 bool fastcat::Manager::InitHardware()

--- a/src/manager.h
+++ b/src/manager.h
@@ -47,6 +47,12 @@ class Manager
    */
   bool ConfigFromYaml(const YAML::Node& node, double external_time = -1);
 
+  /** @brief Initializes EtherCAT hardware (executes deferred jsd_init calls)
+   *
+   *  @return true on successful hardware initialization. If false, application should quit.
+   */
+  bool InitHardware();
+
   /** @brief Updates synchronous PDO and background async SDO requests.
    *
    *  Process() proceeds by
@@ -245,6 +251,13 @@ class Manager
   std::map<std::string, ActuatorPosData>             actuator_pos_map_;
   std::unordered_map<std::string, bool>              unique_device_map_;
   std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;
+
+  struct JsdBusInitParams {
+    std::string ifname;
+    jsd_t*      jsd;
+    bool        enable_autorecovery;
+  };
+  std::vector<JsdBusInitParams> pending_jsd_inits_;
 
   std::mutex parameter_mutex_;
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -47,6 +47,12 @@ class Manager
    */
   bool ConfigFromYaml(const YAML::Node& node, double external_time = -1);
 
+  /** @brief Parses YAML configuration and creates device objects (no hardware init)
+   *
+   *  @return true on successful configuration. If false, application should quit.
+   */
+  bool CreateConfigFromYaml(const YAML::Node& node, double external_time = -1);
+
   /** @brief Initializes EtherCAT hardware (executes deferred jsd_init calls)
    *
    *  @return true on successful hardware initialization. If false, application should quit.

--- a/src/manager.h
+++ b/src/manager.h
@@ -240,6 +240,11 @@ class Manager
   void GetActuatorPositions();
   void SaveActuatorPosFile();
   bool CheckDeviceNameIsUnique(std::string name);
+  struct JsdBusInitParams {
+    std::string ifname;
+    jsd_t*      jsd;
+    bool        enable_autorecovery;
+  };
 
   double                        target_loop_rate_hz_                = 0.0;
   bool                          zero_latency_required_              = true;
@@ -258,11 +263,6 @@ class Manager
   std::unordered_map<std::string, bool>              unique_device_map_;
   std::shared_ptr<std::queue<SdoResponse>>           sdo_response_queue_;
 
-  struct JsdBusInitParams {
-    std::string ifname;
-    jsd_t*      jsd;
-    bool        enable_autorecovery;
-  };
   std::vector<JsdBusInitParams> pending_jsd_inits_;
 
   std::mutex parameter_mutex_;

--- a/test/test_cli.cc
+++ b/test/test_cli.cc
@@ -474,6 +474,11 @@ int main(int argc, char* argv[])
     return 0;
   }
 
+  if (!manager.InitHardware()) {
+    ERROR("Could not initialize Fastcat Manager hardware");
+    return 0;
+  }
+
   pthread_t cli_thread;
   int       retval;
   double    loop_rate = manager.GetTargetLoopRate();


### PR DESCRIPTION
Divide ConfigFromYaml in two steps: CreateConfigFromYaml & InitHardware. This is required for Icicle board because time between ConfigFromYaml and Process is too long, but some of the setup requires to read the config. I updated readme to reflect changes

Calling ConfigFromYaml does not change. 

@JosephBowkett @kwehage @preston-rogers @dwai-wai