### PR TITLE
Prestonr switched on check

### DIFF
--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -25,9 +25,7 @@ fastcat::Actuator::Actuator()
 bool fastcat::Actuator::ConfigFromYaml(const YAML::Node& node)
 {
   actuator_sms_ = ACTUATOR_SMS_HALTED;
-  elmo_state_machine_state_initialized_ = false;
-  last_elmo_state_machine_state_ =
-      JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
+  last_elmo_state_machine_state_ = JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
 
   // monotonic_initialization_time_sec_ set by base class method
   // SetInitializationTime, which must be called prior to ConfigFromYaml
@@ -231,10 +229,6 @@ bool fastcat::Actuator::Read()
 {
   ElmoRead();
   PopulateState();
-  if (!elmo_state_machine_state_initialized_) {
-    last_elmo_state_machine_state_ = GetElmoStateMachineState();
-    elmo_state_machine_state_initialized_ = true;
-  }
   return true;
 }
 
@@ -491,10 +485,6 @@ fastcat::FaultType fastcat::Actuator::Process()
       ERROR("Bad Actuator State Machine State: %d", actuator_sms_);
       retval = ALL_DEVICE_FAULT;
       break;
-  }
-
-  if (elmo_state_machine_state_initialized_) {
-    last_elmo_state_machine_state_ = GetElmoStateMachineState();
   }
 
   ElmoProcess();

--- a/src/jsd/actuator.cc
+++ b/src/jsd/actuator.cc
@@ -25,6 +25,9 @@ fastcat::Actuator::Actuator()
 bool fastcat::Actuator::ConfigFromYaml(const YAML::Node& node)
 {
   actuator_sms_ = ACTUATOR_SMS_HALTED;
+  elmo_state_machine_state_initialized_ = false;
+  last_elmo_state_machine_state_ =
+      JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
 
   // monotonic_initialization_time_sec_ set by base class method
   // SetInitializationTime, which must be called prior to ConfigFromYaml
@@ -228,6 +231,10 @@ bool fastcat::Actuator::Read()
 {
   ElmoRead();
   PopulateState();
+  if (!elmo_state_machine_state_initialized_) {
+    last_elmo_state_machine_state_ = GetElmoStateMachineState();
+    elmo_state_machine_state_initialized_ = true;
+  }
   return true;
 }
 
@@ -484,6 +491,10 @@ fastcat::FaultType fastcat::Actuator::Process()
       ERROR("Bad Actuator State Machine State: %d", actuator_sms_);
       retval = ALL_DEVICE_FAULT;
       break;
+  }
+
+  if (elmo_state_machine_state_initialized_) {
+    last_elmo_state_machine_state_ = GetElmoStateMachineState();
   }
 
   ElmoProcess();

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -262,7 +262,6 @@ class Actuator : public JsdDeviceBase
 
   bool    actuator_absolute_encoder_ = false;
   int32_t elmo_pos_offset_cnts_      = 1;
-  bool elmo_state_machine_state_initialized_ = false;
   jsd_elmo_state_machine_state_t last_elmo_state_machine_state_ =
       JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
   RingBuffer<DeviceCmd> last_device_cmd_ = RingBuffer<DeviceCmd>(50);

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -175,6 +175,9 @@ class Actuator : public JsdDeviceBase
   ActuatorFastcatFault fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_OKAY;
 
   DeviceCmd last_cmd_ = {};
+  
+  jsd_elmo_state_machine_state_t last_elmo_state_machine_state_ =
+    JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
 
   // Timeout in seconds after which a fault should occur if a transition out of
   // PROF_*_DISENGAGING does not take place. Default value corresponds to the
@@ -263,8 +266,6 @@ class Actuator : public JsdDeviceBase
 
   bool    actuator_absolute_encoder_ = false;
   int32_t elmo_pos_offset_cnts_      = 1;
-  jsd_elmo_state_machine_state_t last_elmo_state_machine_state_ =
-      JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
   RingBuffer<DeviceCmd> last_device_cmd_ = RingBuffer<DeviceCmd>(50);
   double csp_interpolation_offset_time_ = 0.0;
   size_t csp_cycles_delay_ = 4;

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -262,6 +262,9 @@ class Actuator : public JsdDeviceBase
 
   bool    actuator_absolute_encoder_ = false;
   int32_t elmo_pos_offset_cnts_      = 1;
+  bool elmo_state_machine_state_initialized_ = false;
+  jsd_elmo_state_machine_state_t last_elmo_state_machine_state_ =
+      JSD_ELMO_STATE_MACHINE_STATE_NOT_READY_TO_SWITCH_ON;
   RingBuffer<DeviceCmd> last_device_cmd_ = RingBuffer<DeviceCmd>(50);
   double csp_interpolation_offset_time_ = 0.0;
   size_t csp_cycles_delay_ = 4;

--- a/src/jsd/actuator.h
+++ b/src/jsd/actuator.h
@@ -10,6 +10,7 @@
 #include "fastcat/trap.h"
 #include "fastcat/ring_buffer.h"
 #include "jsd/jsd_elmo_common_types.h"
+#include "jsd/jsd_elmo_common.h"
 
 namespace fastcat
 {

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -547,10 +547,10 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
     return true;
   }
   auto elmo_state_machine_state = GetElmoStateMachineState();
-  if (elmo_state_machine_state_initialized_ &&
-      last_elmo_state_machine_state_ ==
+  if (last_elmo_state_machine_state_ ==
           JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED &&
-      elmo_state_machine_state == JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) {
+      elmo_state_machine_state == 
+          JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) {
     ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
           "to SWITCHED_ON during motion",
           name_.c_str());
@@ -563,9 +563,7 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
       elmo_state_machine_state ==
           JSD_ELMO_STATE_MACHINE_STATE_FAULT_REACTION_ACTIVE ||
       elmo_state_machine_state ==
-          JSD_ELMO_STATE_MACHINE_STATE_FAULT ||
-      elmo_state_machine_state == 
-          JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) {
+          JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
     ERROR("%s: Elmo drive state machine state is off nominal", name_.c_str());
     fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
     return true;

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -582,11 +582,13 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
   }
   else if (elmo_state_machine_state ==
         JSD_ELMO_STATE_MACHINE_STATE_FAULT_REACTION_ACTIVE) {
-    ERROR("%s: Elmo drive state machine transitioned from %s to "
+    ERROR("%s: Elmo drive state machine transitioned from %s "
       "to %s during motion! The drive just triggered a fault.",
-      name_.c_str(), 
+      name_.c_str(),
       jsd_elmo_state_machine_state_to_string(last_elmo_state_machine_state_),
       jsd_elmo_state_machine_state_to_string(elmo_state_machine_state));
+    fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+    return true;
   }
   return false;
 }

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -551,30 +551,43 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
           JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED) {
     if (elmo_state_machine_state == 
           JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) {
-      ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
-          "to SWITCHED_ON during motion! This transition should not occur.",
-          name_.c_str());
+      ERROR("%s: Elmo drive state machine transitioned from %s "
+          "to %s during motion! This transition should not occur.",
+          name_.c_str(), 
+          jsd_elmo_state_machine_state_to_string(last_elmo_state_machine_state_),
+          jsd_elmo_state_machine_state_to_string(elmo_state_machine_state));
       fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
       return true;
     }
-    else if (elmo_state_machine_state == 
-          JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE) {
-      ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
-          "to QUICK_STOP_ACTIVE during motion! Likely due to fastcat fault.",
-          name_.c_str());
-      fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
-      return true;
-    }
-    else if (elmo_state_machine_state ==
-          JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
-      ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
-        "to FAULT during motion! This fault arose from the drive itself.",
-        name_.c_str());
-      fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
-      return true;
-    }
+  } 
+  if (elmo_state_machine_state == 
+        JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE) {
+    ERROR("%s: Elmo drive state machine transitioned from %s "
+        "to %s during motion! This is likely due to fastcat fault.",
+        name_.c_str(), 
+        jsd_elmo_state_machine_state_to_string(last_elmo_state_machine_state_),
+        jsd_elmo_state_machine_state_to_string(elmo_state_machine_state));
+    fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+    return true;
   }
-
+  else if (elmo_state_machine_state ==
+        JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
+    ERROR("%s: Elmo drive state machine transitioned from %s "
+      "to %s during motion! This fault arose from the drive itself.",
+      name_.c_str(),
+      jsd_elmo_state_machine_state_to_string(last_elmo_state_machine_state_),
+      jsd_elmo_state_machine_state_to_string(elmo_state_machine_state));
+    fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+    return true;
+  }
+  else if (elmo_state_machine_state ==
+        JSD_ELMO_STATE_MACHINE_STATE_FAULT_REACTION_ACTIVE) {
+    ERROR("%s: Elmo drive state machine transitioned from %s to "
+      "to %s during motion! The drive just triggered a fault.",
+      name_.c_str(), 
+      jsd_elmo_state_machine_state_to_string(last_elmo_state_machine_state_),
+      jsd_elmo_state_machine_state_to_string(elmo_state_machine_state));
+  }
   return false;
 }
 

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -548,26 +548,33 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
   }
   auto elmo_state_machine_state = GetElmoStateMachineState();
   if (last_elmo_state_machine_state_ ==
-          JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED &&
-      elmo_state_machine_state == 
+          JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED) {
+    if (elmo_state_machine_state == 
           JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) {
-    ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
-          "to SWITCHED_ON during motion",
+      ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
+          "to SWITCHED_ON during motion! This transition should not occur.",
           name_.c_str());
-    fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
-    return true;
+      fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+      return true;
+    }
+    else if (elmo_state_machine_state == 
+          JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE) {
+      ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
+          "to QUICK_STOP_ACTIVE during motion! Likely due to fastcat fault.",
+          name_.c_str());
+      fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+      return true;
+    }
+    else if (elmo_state_machine_state ==
+          JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
+      ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
+        "to FAULT during motion! This fault arose from the drive itself.",
+        name_.c_str());
+      fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+      return true;
+    }
   }
 
-  if (elmo_state_machine_state ==
-          JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE ||
-      elmo_state_machine_state ==
-          JSD_ELMO_STATE_MACHINE_STATE_FAULT_REACTION_ACTIVE ||
-      elmo_state_machine_state ==
-          JSD_ELMO_STATE_MACHINE_STATE_FAULT) {
-    ERROR("%s: Elmo drive state machine state is off nominal", name_.c_str());
-    fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
-    return true;
-  }
   return false;
 }
 

--- a/src/jsd/actuator_fsm_helpers.cc
+++ b/src/jsd/actuator_fsm_helpers.cc
@@ -547,6 +547,17 @@ bool fastcat::Actuator::IsMotionFaultConditionMet()
     return true;
   }
   auto elmo_state_machine_state = GetElmoStateMachineState();
+  if (elmo_state_machine_state_initialized_ &&
+      last_elmo_state_machine_state_ ==
+          JSD_ELMO_STATE_MACHINE_STATE_OPERATION_ENABLED &&
+      elmo_state_machine_state == JSD_ELMO_STATE_MACHINE_STATE_SWITCHED_ON) {
+    ERROR("%s: Elmo drive state machine transitioned from OPERATION_ENABLED "
+          "to SWITCHED_ON during motion",
+          name_.c_str());
+    fastcat_fault_ = ACTUATOR_FASTCAT_FAULT_INVALID_ELMO_SMS_DURING_MOTION;
+    return true;
+  }
+
   if (elmo_state_machine_state ==
           JSD_ELMO_STATE_MACHINE_STATE_QUICK_STOP_ACTIVE ||
       elmo_state_machine_state ==

--- a/src/jsd/gold_actuator.cc
+++ b/src/jsd/gold_actuator.cc
@@ -76,6 +76,8 @@ void fastcat::GoldActuator::PopulateState()
 
   state_->gold_actuator_state.cmd_max_current = jsd_egd_state_.cmd_max_current;
 
+  last_elmo_state_machine_state_ = static_cast<jsd_elmo_state_machine_state_t>(
+      state_->gold_actuator_state.elmo_state_machine_state);
   state_->gold_actuator_state.elmo_state_machine_state =
       static_cast<uint32_t>(jsd_egd_state_.actual_state_machine_state);
   state_->gold_actuator_state.elmo_mode_of_operation =

--- a/src/jsd/platinum_actuator.cc
+++ b/src/jsd/platinum_actuator.cc
@@ -82,6 +82,8 @@ void fastcat::PlatinumActuator::PopulateState()
   state_->platinum_actuator_state.cmd_max_current =
       jsd_epd_state_.cmd_max_current;
 
+  last_elmo_state_machine_state_ = static_cast<jsd_elmo_state_machine_state_t>(
+      state_->platinum_actuator_state.elmo_state_machine_state);
   state_->platinum_actuator_state.elmo_state_machine_state =
       static_cast<uint32_t>(jsd_epd_state_.actual_state_machine_state);
   state_->platinum_actuator_state.elmo_mode_of_operation =


### PR DESCRIPTION
Modification to MR [161](https://github.com/nasa-jpl/fastcat/pull/161).

Previously, the actuator would error out immediately when SWITCHED_ON was experienced.
The true issue is the transition from OPERATION_ENABLED to SWITCHED_ON which requires time for the typical initialization process to get to OPERATION_ENABLED first before SWITCHED_ON is truly an error scenario.